### PR TITLE
add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,32 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo
+*              @emilgoldsmith @zanemountcastle
+
+# Beware that order is important, the last matching pattern has the most precedence.
+
+# Zane has default ownership of all css and scss files
+*.css          @zanemountcastle
+*.scss         @zanemountcastle
+
+# Zane has ownership of the styles folder
+src/styles/*   @zanemountcastle
+
+# Zane has ownership of the components file (but not the editor subfolder
+# which will be overwritten in the following definition)
+src/components/* @zanemountcastle
+
+# Emil has ownership over the editor components
+src/components/editor/*   @emilgoldsmith
+
+# Emil has ownership over the lib folder
+src/lib/*          @emilgoldsmith
+
+# Zane has ownership over the transitions folder
+src/transitions/*  @zanemountcastle
+
+# Emil has ownership over client-scripts, server-code folders and index.js
+src/client-scripts/*  @emilgoldsmith
+src/server-code/*     @emilgoldsmith
+src/index.js          @emilgoldsmith


### PR DESCRIPTION
Just quickly setup a CODEOWNERS file as explained [here](https://github.com/blog/2392-introducing-code-owners). It's a pretty new feature I fell over this summer that I found quite neat and thinking about how we would for example want @zanemountcastle to look over @joaquinkunkel's css changes before it merged in etc. just made me think I'd quickly set one up.

@zanemountcastle if you could just take a look, if you see any typos feel free to correct of course, and otherwise if you feel something is off, like if I was too heavyhanded only putting me on lib or something like that just say so. Remember that this doesn't mean that no one else can review the PRs of course, it just means the PRs can't be merged (at least without admin privileges) without the code owner(s) having approved the PR, and it for example I guess would be nice for that to work for having you having to look at the styles folder or the main components folder, and me looking at all changes to `db.js`, `falcorRouter` etc.