### PR TITLE
make eslint fail on warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-production": "./node_modules/.bin/webpack -p --config ./webpack.production.config.js --bail",
     "build-beta": "./node_modules/.bin/webpack -p --config ./webpack.beta.config.js --bail",
     "test": "jest",
-    "lint": "eslint '{src,__tests__}/**/*.{js,jsx}'"
+    "lint": "eslint --max-warnings 0 '{src,__tests__}/**/*.{js,jsx}'"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/components/editor/EditorMainIssueController.jsx
+++ b/src/components/editor/EditorMainIssueController.jsx
@@ -128,7 +128,6 @@ export default class EditorMainIssueController extends FalcorController {
         const articlesValid = allArticles.every(article => {
           const fieldsValid = fields.every((field) => {
             if (!article[field]) {
-              console.log(article);
               window.alert(`${article.title} has no ${field}. Please correct this`);
               return false;
             }


### PR DESCRIPTION
I just noticed as I was fixing up #221 that there was a warning being emitted by the linter, an old debugging log from #219. The CI hadn't caught this because we apparently needed to add an option to the eslint command, so I did so :).