### PR TITLE
Add a precommit hook that runs tests and linting

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4512,6 +4512,31 @@
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
       "dev": true
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
+      }
+    },
     "hyphenate-style-name": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
@@ -4717,6 +4742,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
       "integrity": "sha1-XuWOqlounIDiFAe+3yOuWsCRs/w="
+    },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.0.0"
+      }
     },
     "is-dotfile": {
       "version": "1.0.2",
@@ -8686,14 +8720,6 @@
         }
       }
     },
-    "require_optional": {
-      "version": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
-      "integrity": "sha1-UqhhN6hJco62ClVTNhf4+RT1mr8=",
-      "requires": {
-        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-      }
-    },
     "require-directory": {
       "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
@@ -8718,6 +8744,14 @@
           "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
           "dev": true
         }
+      }
+    },
+    "require_optional": {
+      "version": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+      "integrity": "sha1-UqhhN6hJco62ClVTNhf4+RT1mr8=",
+      "requires": {
+        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
       }
     },
     "resolve": {
@@ -9326,10 +9360,6 @@
       "version": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -9352,6 +9382,10 @@
         "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
         "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
       }
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build-production": "./node_modules/.bin/webpack -p --config ./webpack.production.config.js --bail",
     "build-beta": "./node_modules/.bin/webpack -p --config ./webpack.beta.config.js --bail",
     "test": "jest",
-    "lint": "eslint --max-warnings 0 '{src,__tests__}/**/*.{js,jsx}'"
+    "lint": "eslint --max-warnings 0 '{src,__tests__}/**/*.{js,jsx}'",
+    "precommit": "npm run lint && npm test"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -57,6 +58,7 @@
     "eslint-plugin-react": "^5.1.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
+    "husky": "^0.14.3",
     "jest": "^20.0.4",
     "node-sass": "^4.5.3",
     "null-loader": "^0.1.1",


### PR DESCRIPTION
This is something I've thought about for a while after running into it in other open source projects, and then just now while I was running tests where I don't get the webpack watch updates on my linting errors it was just pretty annoying every time having the build fail and having to push a `git commit -m "linting fixes"` commit just for that.

This can also be configured locally in your git settings (if you don't know precommit hooks basically every time you run `git commit` it'll run the hook and if it fails you won't commit), but what Husky does is allow it to be global and be shipped with `package.json` and I think it could be nice for everyone, especially beginners but as seen for me here obviously also more advanced users. And if you for some reason (you have a temporary `console.log` and for some reason really want to commit it) want to commit even though the hook is failing you simply add a `--no-verify` option to your commit command as such: `git commit --no-verify -m "some message"` and it won't run the hook.

The biggest thing I could think of right now that could be different is I could possibly see an argument for just running linting tests and not the unit tests if our unit tests get slower in the future, but of course if you have arguments for not having this feature other than that, feel free to pitch in. This is pretty subjective in terms of workflow preferences I guess (since the CI will check it anyway so it's not like not having this means we don't test our code), but I quite like it.