### PR TITLE
Feature/first dynamic e2e tests

### DIFF
--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -2,6 +2,8 @@ FROM circleci/node:7.10
 
 RUN sudo apt-get install mysql-client
 
+RUN sudo npm i -g forever
+
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
 
 # Enable NVM and install node 4.2

--- a/.circleci/images/primary/update-image.sh
+++ b/.circleci/images/primary/update-image.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+TAG=$1
+
+NAME="thegazelle/gazelle-main-circleci-primary:$TAG"
+
+sudo docker build -t $NAME . && sudo docker push $NAME

--- a/__tests__/end-to-end/admin-tests/assets/checkServerRestarted.js
+++ b/__tests__/end-to-end/admin-tests/assets/checkServerRestarted.js
@@ -1,0 +1,8 @@
+// In order to avoid 'undefined has no property X' errors
+window.THE_GAZELLE = {};
+// Redefine window.alert from what Nightmare does in preload script to the check we need
+window.alert = msg => {
+  if (msg === 'Server restarted successfully') {
+    window.THE_GAZELLE.serverRestartedSuccessfully = true;
+  }
+};

--- a/__tests__/end-to-end/admin-tests/author-list.test.js
+++ b/__tests__/end-to-end/admin-tests/author-list.test.js
@@ -1,0 +1,82 @@
+import { isVisible } from '__tests__/end-to-end/e2e-utilities';
+import { SIMPLE_TEST_TIMEOUT } from '__tests__/end-to-end/e2e-constants';
+import { getLoggedInState } from './e2e-admin-utilities';
+
+jest.setTimeout(SIMPLE_TEST_TIMEOUT);
+
+describe('Admin interface author list', () => {
+  const authorListSelector = '#author-list';
+  const getTabButtonSelector = index => (
+    `${authorListSelector} button[type="button"]:nth-child(${index})`
+  );
+  const addNewTabSelector = '#author-list-add-new-tab';
+  const editTabSelector = '#author-list-edit-tab';
+  const authorEditorSelector = '#author-editor';
+
+  it('searches correctly for authors', () => {
+    expect.assertions(1);
+
+    const inputElementSelector = `${authorListSelector} .search-bar-authors input[type="text"]`;
+    // There should only be one result so it'll therefore be the first one
+    const searchItemSelector = `${authorListSelector} .search-bar-authors .search-bar-result`;
+    return getLoggedInState('/authors')
+      .wait(inputElementSelector)
+      .insert(inputElementSelector, 'Emil Goldsmith Olesen')
+      .wait(searchItemSelector)
+      // We click on the Material UI element where the onClick handler is actually set
+      .click(`${searchItemSelector} span[role="menuitem"]`)
+      .wait(authorEditorSelector)
+      .path()
+      .end()
+      .then((path) => {
+        expect(path).toBe('/authors/emil-goldsmith-olesen');
+      });
+  });
+
+  it('correctly switches tabs', () => (
+    getLoggedInState('/authors')
+      .wait(authorListSelector)
+      // Click 'Add New' tab
+      .click(getTabButtonSelector(2))
+      .wait(addNewTabSelector)
+      // Click 'Edit' tab
+      .click(getTabButtonSelector(1))
+      .wait(editTabSelector)
+      // The waits make sure we actually routed to the right elements
+      // so no further checks are needed
+      .end()
+  ));
+
+  it('correctly adds new authors', () => {
+    expect.assertions(1);
+
+    // We first create a new author with a unique name
+    const authorName = `test-user-${new Date().getTime()}`;
+    const getInputSelector = index => `${addNewTabSelector} form div:nth-of-type(${index}) input`;
+    const createAuthorSelector = `${addNewTabSelector} button[type="submit"]`;
+    return getLoggedInState('/authors')
+      .wait(authorListSelector)
+      // Click 'Add New' tab
+      // We use mouseup here because of weird Material UI behaviour with the touchtap event it uses
+      // we should be able to change this to click when Material UI 1.0 is released
+      .mouseup(getTabButtonSelector(2))
+      // We use isVisible here as opposed to wait because Material UI doesn't actually remove
+      // the other tab from the DOM tree, but instead makes them invisible by setting height=0px.
+      // The true flag indicates checking the parent element as our selector is to the child of
+      // the main tab div Material UI hides
+      .wait(isVisible, addNewTabSelector, true)
+      // Input name
+      .insert(getInputSelector(1), authorName)
+      // Input slug
+      .insert(getInputSelector(2), authorName.substr(0, authorName.length - 1))
+      // We type the last character to fire the events to enable the create author button
+      .type(getInputSelector(2), authorName.substr(authorName.length - 1, 1))
+      .click(createAuthorSelector)
+      .wait(authorEditorSelector)
+      .path()
+      .end()
+      .then(path => {
+        expect(path).toBe(`/authors/${authorName}`);
+      });
+  });
+});

--- a/__tests__/end-to-end/admin-tests/e2e-admin-constants.js
+++ b/__tests__/end-to-end/admin-tests/e2e-admin-constants.js
@@ -1,0 +1,1 @@
+export const HOST = 'http://localhost:4000';

--- a/__tests__/end-to-end/admin-tests/e2e-admin-utilities.js
+++ b/__tests__/end-to-end/admin-tests/e2e-admin-utilities.js
@@ -1,13 +1,10 @@
-import Nightmare from 'nightmare';
-
 import { HOST } from './e2e-admin-constants';
+import { ENTER_UNICODE } from '__tests__/end-to-end/e2e-constants';
 
-export function getLoggedInState(path) {
-  const nightmare = new Nightmare();
-
+export function getLoggedInState(nightmare, path) {
   const passwordInputSelector = 'input[type="password"]';
   return nightmare
-    // We use this to detect errors in rendering
+    // We use this to detect client-side errors in rendering
     .on('page', (type, message, stack) => {
       if (type !== 'error') return;
       throw new Error(`${message}\nstack trace: ${stack}`);
@@ -17,17 +14,16 @@ export function getLoggedInState(path) {
     .wait(passwordInputSelector)
     // Write password
     .insert(passwordInputSelector, process.env.CIRCLECI_ADMIN_PASSWORD)
-    // Press enter
-    .type(passwordInputSelector, '\u000d');
+    .type(passwordInputSelector, ENTER_UNICODE);
 }
 
-export function restartServer() {
+export function restartServer(nightmare) {
   const headerSelector = '#app-header';
   const headerMenuButtonSelector = `${headerSelector}-menu-button`;
   const restartServerButtonSelector = `${headerSelector}-restart-button`;
   const restartServerPasswordInputSelector = '#restart-server-password-input';
 
-  return getLoggedInState('')
+  return getLoggedInState(nightmare, '')
     // We inject a script that sets window.THE_GAZELLE.serverRestartedSuccessfully = true when
     // the correct `window.alert` call has been made
     .inject('js', `${__dirname}/assets/checkServerRestarted.js`)
@@ -39,8 +35,21 @@ export function restartServer() {
     .wait(restartServerPasswordInputSelector)
     // Insert restart server password
     .insert(restartServerPasswordInputSelector, process.env.CIRCLECI_ADMIN_PASSWORD)
-    // Press enter
-    .type(restartServerPasswordInputSelector, '\u000d')
+    .type(restartServerPasswordInputSelector, ENTER_UNICODE)
     .wait(() => window.THE_GAZELLE.serverRestartedSuccessfully)
     .end();
+}
+
+export function isVisible(selector, evaluateParent = false) {
+  let element = document.querySelector(selector);
+  if (evaluateParent) {
+    element = element.parentNode;
+  }
+  return (
+    element.style.width !== '0' &&
+    element.style.width !== '0px' &&
+    element.style.height !== '0' &&
+    element.style.height !== '0px' &&
+    element.style.display !== 'none'
+  );
 }

--- a/__tests__/end-to-end/admin-tests/e2e-admin-utilities.js
+++ b/__tests__/end-to-end/admin-tests/e2e-admin-utilities.js
@@ -1,0 +1,22 @@
+import Nightmare from 'nightmare';
+
+import { HOST } from './e2e-admin-constants';
+
+export function getLoggedInState(path) {
+  const nightmare = new Nightmare();
+
+  const passwordInputSelector = 'input[type="password"]';
+  return nightmare
+    // We use this to detect errors in rendering
+    .on('page', (type, message, stack) => {
+      if (type !== 'error') return;
+      throw new Error(`${message}\nstack trace: ${stack}`);
+    })
+    .goto(`${HOST}${path}`)
+    // Wait for the input element to render
+    .wait(passwordInputSelector)
+    // Write password
+    .insert(passwordInputSelector, process.env.CIRCLECI_ADMIN_PASSWORD)
+    // Press enter
+    .type(passwordInputSelector, '\u000d');
+}

--- a/__tests__/end-to-end/admin-tests/e2e-admin-utilities.js
+++ b/__tests__/end-to-end/admin-tests/e2e-admin-utilities.js
@@ -20,3 +20,27 @@ export function getLoggedInState(path) {
     // Press enter
     .type(passwordInputSelector, '\u000d');
 }
+
+export function restartServer() {
+  const headerSelector = '#app-header';
+  const headerMenuButtonSelector = `${headerSelector}-menu-button`;
+  const restartServerButtonSelector = `${headerSelector}-restart-button`;
+  const restartServerPasswordInputSelector = '#restart-server-password-input';
+
+  return getLoggedInState('')
+    // We inject a script that sets window.THE_GAZELLE.serverRestartedSuccessfully = true when
+    // the correct `window.alert` call has been made
+    .inject('js', `${__dirname}/assets/checkServerRestarted.js`)
+    .wait(headerMenuButtonSelector)
+    // mouseup for Material UI quirk
+    .mouseup(headerMenuButtonSelector)
+    .wait(restartServerButtonSelector)
+    .click(restartServerButtonSelector)
+    .wait(restartServerPasswordInputSelector)
+    // Insert restart server password
+    .insert(restartServerPasswordInputSelector, process.env.CIRCLECI_ADMIN_PASSWORD)
+    // Press enter
+    .type(restartServerPasswordInputSelector, '\u000d')
+    .wait(() => window.THE_GAZELLE.serverRestartedSuccessfully)
+    .end();
+}

--- a/__tests__/end-to-end/admin-tests/header.test.js
+++ b/__tests__/end-to-end/admin-tests/header.test.js
@@ -1,9 +1,27 @@
+import Nightmare from 'nightmare';
+
 import { getLoggedInState } from './e2e-admin-utilities';
-import { SIMPLE_TEST_TIMEOUT } from '__tests__/end-to-end/e2e-constants';
+import {
+  SIMPLE_TEST_TIMEOUT,
+  NIGHTMARE_CONFIG,
+  ENTER_UNICODE,
+} from '__tests__/end-to-end/e2e-constants';
 
 jest.setTimeout(SIMPLE_TEST_TIMEOUT);
 
 describe('Admin header', () => {
+  let nightmare = null;
+  beforeEach(() => {
+    nightmare = new Nightmare(NIGHTMARE_CONFIG);
+  });
+
+  afterEach(() => {
+    // Kill the nightmare instance, this won't make a difference if everything worked as expected
+    // but if we don't have it when something doesn't go as unexpected it can make jest hang
+    // and not terminate
+    nightmare.halt();
+  });
+
   const headerSelector = '#app-header';
 
   it('signs out correctly', () => {
@@ -12,7 +30,7 @@ describe('Admin header', () => {
     const headerMenuButtonSelector = `${headerSelector}-menu-button`;
     const signOutSelector = `${headerSelector}-sign-out-button`;
     const loginPageSelector = '#login-page';
-    return getLoggedInState('')
+    return getLoggedInState(nightmare, '')
       .wait(headerMenuButtonSelector)
       // mouseup for Material UI quirk
       .mouseup(headerMenuButtonSelector)
@@ -34,7 +52,7 @@ describe('Admin header', () => {
     const restartServerCancelSelector = '#restart-server-password-cancel';
 
     const testRestartServer = useEnter => {
-      const passwordInsertedState = getLoggedInState('')
+      const passwordInsertedState = getLoggedInState(nightmare, '')
         // We inject a script that sets window.THE_GAZELLE.serverRestartedSuccessfully = true when
         // the correct `window.alert` call has been made
         .inject('js', `${__dirname}/assets/checkServerRestarted.js`)
@@ -50,7 +68,7 @@ describe('Admin header', () => {
       let passwordSubmittedState;
       if (useEnter) {
         passwordSubmittedState = passwordInsertedState
-          .type(restartServerPasswordInputSelector, '\u000d');
+          .type(restartServerPasswordInputSelector, ENTER_UNICODE);
       } else {
         passwordSubmittedState = passwordInsertedState.click(restartServerSubmitSelector);
       }
@@ -64,7 +82,7 @@ describe('Admin header', () => {
     it('works with pressing submit', () => testRestartServer(false));
 
     it('works pressing cancel in modal', () => (
-      getLoggedInState('')
+      getLoggedInState(nightmare, '')
         // We inject a script that sets window.THE_GAZELLE.serverRestartedSuccessfully = true when
         // the correct `window.alert` call has been made
         .inject('js', `${__dirname}/assets/checkServerRestarted.js`)

--- a/__tests__/end-to-end/admin-tests/header.test.js
+++ b/__tests__/end-to-end/admin-tests/header.test.js
@@ -1,4 +1,7 @@
 import { getLoggedInState } from './e2e-admin-utilities';
+import { SIMPLE_TEST_TIMEOUT } from '__tests__/end-to-end/e2e-constants';
+
+jest.setTimeout(SIMPLE_TEST_TIMEOUT);
 
 describe('Admin header', () => {
   const headerSelector = '#app-header';
@@ -21,5 +24,63 @@ describe('Admin header', () => {
       .then(path => {
         expect(path).toBe('/login');
       });
+  });
+
+  describe('restarting server', () => {
+    const headerMenuButtonSelector = `${headerSelector}-menu-button`;
+    const restartServerButtonSelector = `${headerSelector}-restart-button`;
+    const restartServerPasswordInputSelector = '#restart-server-password-input';
+    const restartServerSubmitSelector = '#restart-server-password-submit';
+    const restartServerCancelSelector = '#restart-server-password-cancel';
+
+    const testRestartServer = useEnter => {
+      const passwordInsertedState = getLoggedInState('')
+        // We inject a script that sets window.THE_GAZELLE.serverRestartedSuccessfully = true when
+        // the correct `window.alert` call has been made
+        .inject('js', `${__dirname}/assets/checkServerRestarted.js`)
+        .wait(headerMenuButtonSelector)
+        // mouseup for Material UI quirk
+        .mouseup(headerMenuButtonSelector)
+        .wait(restartServerButtonSelector)
+        .click(restartServerButtonSelector)
+        .wait(restartServerPasswordInputSelector)
+        // Insert restart server password
+        .insert(restartServerPasswordInputSelector, process.env.CIRCLECI_ADMIN_PASSWORD);
+
+      let passwordSubmittedState;
+      if (useEnter) {
+        passwordSubmittedState = passwordInsertedState
+          .type(restartServerPasswordInputSelector, '\u000d');
+      } else {
+        passwordSubmittedState = passwordInsertedState.click(restartServerSubmitSelector);
+      }
+
+      return passwordSubmittedState
+        .wait(() => window.THE_GAZELLE.serverRestartedSuccessfully)
+        .end();
+    };
+
+    it('works with pressing enter', () => testRestartServer(true));
+    it('works with pressing submit', () => testRestartServer(false));
+
+    it('works pressing cancel in modal', () => (
+      getLoggedInState('')
+        // We inject a script that sets window.THE_GAZELLE.serverRestartedSuccessfully = true when
+        // the correct `window.alert` call has been made
+        .inject('js', `${__dirname}/assets/checkServerRestarted.js`)
+        .wait(headerMenuButtonSelector)
+        // mouseup for Material UI quirk
+        .mouseup(headerMenuButtonSelector)
+        .wait(restartServerButtonSelector)
+        .click(restartServerButtonSelector)
+        .wait(restartServerCancelSelector)
+        .click(restartServerCancelSelector)
+        // Make sure modal dissappears
+        .wait(
+          (selector) => document.querySelector(selector) === null,
+          restartServerCancelSelector
+        )
+        .end()
+    ));
   });
 });

--- a/__tests__/end-to-end/admin-tests/header.test.js
+++ b/__tests__/end-to-end/admin-tests/header.test.js
@@ -51,7 +51,7 @@ describe('Admin header', () => {
     const restartServerSubmitSelector = '#restart-server-password-submit';
     const restartServerCancelSelector = '#restart-server-password-cancel';
 
-    const testRestartServer = useEnter => {
+    const testRestartServer = (useEnter = false, initialWrongPassword = false) => {
       const passwordInsertedState = getLoggedInState(nightmare, '')
         // We inject a script that sets window.THE_GAZELLE.serverRestartedSuccessfully = true when
         // the correct `window.alert` call has been made
@@ -66,7 +66,17 @@ describe('Admin header', () => {
         .insert(restartServerPasswordInputSelector, process.env.CIRCLECI_ADMIN_PASSWORD);
 
       let passwordSubmittedState;
-      if (useEnter) {
+      if (initialWrongPassword) {
+        // Add an extra letter to invalidate password, submit it, then submit correct
+        passwordSubmittedState = passwordInsertedState
+          .insert(restartServerPasswordInputSelector, 'a')
+          .type(restartServerPasswordInputSelector, ENTER_UNICODE)
+          // TODO: When we change from the ugly window.alert to a proper banner then check that
+          // the 'invalid password' message shows,
+          // it's too much of a hassle testing it before that.
+          .insert(restartServerPasswordInputSelector, process.env.CIRCLECI_ADMIN_PASSWORD)
+          .type(restartServerPasswordInputSelector, ENTER_UNICODE);
+      } else if (useEnter) {
         passwordSubmittedState = passwordInsertedState
           .type(restartServerPasswordInputSelector, ENTER_UNICODE);
       } else {
@@ -80,6 +90,7 @@ describe('Admin header', () => {
 
     it('works with pressing enter', () => testRestartServer(true));
     it('works with pressing submit', () => testRestartServer(false));
+    it('works with an initial invalid password', () => testRestartServer(false, true));
 
     it('works pressing cancel in modal', () => (
       getLoggedInState(nightmare, '')

--- a/__tests__/end-to-end/admin-tests/header.test.js
+++ b/__tests__/end-to-end/admin-tests/header.test.js
@@ -1,0 +1,25 @@
+import { getLoggedInState } from './e2e-admin-utilities';
+
+describe('Admin header', () => {
+  const headerSelector = '#app-header';
+
+  it('signs out correctly', () => {
+    expect.assertions(1);
+
+    const headerMenuButtonSelector = `${headerSelector}-menu-button`;
+    const signOutSelector = `${headerSelector}-sign-out-button`;
+    const loginPageSelector = '#login-page';
+    return getLoggedInState('')
+      .wait(headerMenuButtonSelector)
+      // mouseup for Material UI quirk
+      .mouseup(headerMenuButtonSelector)
+      .wait(signOutSelector)
+      .click(signOutSelector)
+      .wait(loginPageSelector)
+      .path()
+      .end()
+      .then(path => {
+        expect(path).toBe('/login');
+      });
+  });
+});

--- a/__tests__/end-to-end/admin-tests/login.test.js
+++ b/__tests__/end-to-end/admin-tests/login.test.js
@@ -1,50 +1,74 @@
 import Nightmare from 'nightmare';
 
-import { SIMPLE_TEST_TIMEOUT } from '__tests__/end-to-end/e2e-constants';
+import {
+  SIMPLE_TEST_TIMEOUT,
+  NIGHTMARE_CONFIG,
+  ENTER_UNICODE,
+} from '__tests__/end-to-end/e2e-constants';
 import { HOST } from './e2e-admin-constants';
 
 jest.setTimeout(SIMPLE_TEST_TIMEOUT);
 
-function testLoginRedirect(path, name, useButton = false) {
-  const nightmare = new Nightmare();
+function testLoginRedirect(nightmare, path, useButton = false) {
+  const passwordInputSelector = 'input[type="password"]';
+  const passwordSubmitSelector = 'button[type="submit"]';
+  // The default is because the '/' path actually also redirects to '/articles/page/1'
+  const redirectedPath = !path || path === '/login' ? '/articles/page/1' : path;
 
-  it(name, () => {
-    const passwordInputSelector = 'input[type="password"]';
-    // The default is because the '/' path actually also redirects to '/articles/page/1'
-    const redirectedPath = !path || path === '/login' ? '/articles/page/1' : path;
+  const passwordEnteredState =
+    nightmare
+    // We use this to detect client-side errors in rendering
+    .on('page', (type, message, stack) => {
+      if (type !== 'error') return;
+      throw new Error(`${message}\nstack trace: ${stack}`);
+    })
+    .goto(`${HOST}${path}`)
+    // Wait for the input element to render
+    .wait(passwordInputSelector)
+    // Write password
+    .insert(passwordInputSelector, process.env.CIRCLECI_ADMIN_PASSWORD);
 
-    const passwordEnteredState =
-      nightmare
-      // We use this to detect errors in rendering
-      .on('page', (type, message, stack) => {
-        if (type !== 'error') return;
-        throw new Error(`${message}\nstack trace: ${stack}`);
-      })
-      .goto(`${HOST}${path}`)
-      // Wait for the input element to render
-      .wait(passwordInputSelector)
-      // Write password
-      .insert(passwordInputSelector, process.env.CIRCLECI_ADMIN_PASSWORD);
+  let passwordSubmittedState;
+  if (useButton) {
+    passwordSubmittedState = passwordEnteredState.click(passwordSubmitSelector);
+  } else {
+    passwordSubmittedState = passwordEnteredState.type(passwordInputSelector, ENTER_UNICODE);
+  }
 
-    let passwordSubmittedState;
-    if (useButton) {
-      passwordSubmittedState = passwordEnteredState.click('button[type="submit"]');
-    } else {
-      // Press enter
-      passwordSubmittedState = passwordEnteredState.type(passwordInputSelector, '\u000d');
-    }
-
-    return passwordSubmittedState
-      // Wait until we've rendered the authors page
-      .wait(expectedEndPath => window.location.pathname === expectedEndPath, redirectedPath)
-      .end();
-  });
+  return passwordSubmittedState
+    // Wait until we've rendered the target page
+    .wait(expectedEndPath => window.location.pathname === expectedEndPath, redirectedPath)
+    .end();
 }
 
 describe('Admin login', () => {
-  testLoginRedirect('/login', 'handles redirect after direct access to /login');
-  testLoginRedirect('', 'redirects correctly to front page');
-  testLoginRedirect('/authors', 'redirects correctly to non-front page');
+  let nightmare = null;
+  beforeEach(() => {
+    nightmare = new Nightmare(NIGHTMARE_CONFIG);
+  });
+
+  afterEach(() => {
+    // Kill the nightmare instance, this won't make a difference if everything worked as expected
+    // but if we don't have it when something doesn't go as unexpected it can make jest hang
+    // and not terminate
+    nightmare.halt();
+  });
+
+  it(
+    'handles redirect after direct access to /login',
+    () => testLoginRedirect(nightmare, '/login')
+  );
+  it(
+    'redirects correctly to front page',
+    () => testLoginRedirect(nightmare, '')
+  );
+  it(
+    'redirects correctly to non-front page',
+    () => testLoginRedirect(nightmare, '/authors')
+  );
   // Until now we only submitted by enter so we also check that submitting with button works
-  testLoginRedirect('', 'login works with using button', true);
+  it(
+    'login works with using button',
+    () => testLoginRedirect(nightmare, '', true)
+  );
 });

--- a/__tests__/end-to-end/admin-tests/login.test.js
+++ b/__tests__/end-to-end/admin-tests/login.test.js
@@ -1,6 +1,7 @@
 import Nightmare from 'nightmare';
 
-import { SIMPLE_TEST_TIMEOUT, ADMIN_HOST as HOST } from '../utilities';
+import { SIMPLE_TEST_TIMEOUT } from '__tests__/end-to-end/e2e-constants';
+import { HOST } from './e2e-admin-constants';
 
 jest.setTimeout(SIMPLE_TEST_TIMEOUT);
 

--- a/__tests__/end-to-end/admin-tests/login.test.js
+++ b/__tests__/end-to-end/admin-tests/login.test.js
@@ -1,0 +1,49 @@
+import Nightmare from 'nightmare';
+
+import { SIMPLE_TEST_TIMEOUT, ADMIN_HOST as HOST } from '../utilities';
+
+jest.setTimeout(SIMPLE_TEST_TIMEOUT);
+
+function testLoginRedirect(path, name, useButton = false) {
+  const nightmare = new Nightmare();
+
+  it(name, () => {
+    const passwordInputSelector = 'input[type="password"]';
+    // The default is because the '/' path actually also redirects to '/articles/page/1'
+    const redirectedPath = !path || path === '/login' ? '/articles/page/1' : path;
+
+    const passwordEnteredState =
+      nightmare
+      // We use this to detect errors in rendering
+      .on('page', (type, message, stack) => {
+        if (type !== 'error') return;
+        throw new Error(`${message}\nstack trace: ${stack}`);
+      })
+      .goto(`${HOST}${path}`)
+      // Wait for the input element to render
+      .wait(passwordInputSelector)
+      // Write password
+      .insert(passwordInputSelector, process.env.CIRCLECI_ADMIN_PASSWORD);
+
+    let passwordSubmittedState;
+    if (useButton) {
+      passwordSubmittedState = passwordEnteredState.click('button[type="submit"]');
+    } else {
+      // Press enter
+      passwordSubmittedState = passwordEnteredState.type(passwordInputSelector, '\u000d');
+    }
+
+    return passwordSubmittedState
+      // Wait until we've rendered the authors page
+      .wait(expectedEndPath => window.location.pathname === expectedEndPath, redirectedPath)
+      .end();
+  });
+}
+
+describe('Admin login', () => {
+  testLoginRedirect('/login', 'handles redirect after direct access to /login');
+  testLoginRedirect('', 'redirects correctly to front page');
+  testLoginRedirect('/authors', 'redirects correctly to non-front page');
+  // Until now we only submitted by enter so we also check that submitting with button works
+  testLoginRedirect('', 'login works with using button', true);
+});

--- a/__tests__/end-to-end/admin-tests/serverside-rendering.test.js
+++ b/__tests__/end-to-end/admin-tests/serverside-rendering.test.js
@@ -5,7 +5,9 @@
  */
 import Nightmare from 'nightmare';
 
-import { testPathServersideRender, SIMPLE_TEST_TIMEOUT, ADMIN_HOST as HOST } from '../utilities';
+import { testPathServersideRender } from '__tests__/end-to-end/e2e-utilities';
+import { SIMPLE_TEST_TIMEOUT } from '__tests__/end-to-end/e2e-constants';
+import { HOST } from './e2e-admin-constants';
 
 jest.setTimeout(SIMPLE_TEST_TIMEOUT);
 

--- a/__tests__/end-to-end/e2e-constants.js
+++ b/__tests__/end-to-end/e2e-constants.js
@@ -1,1 +1,11 @@
+export const ENTER_UNICODE = '\u000d';
 export const SIMPLE_TEST_TIMEOUT = 10 * 1000;
+const NIGHTMARE_ACTION_TIMEOUT = (process.env.CIRCLECI ? 4 : 2) * 1000;
+export const NIGHTMARE_CONFIG = {
+  waitTimeout: NIGHTMARE_ACTION_TIMEOUT,
+  gotoTimeout: NIGHTMARE_ACTION_TIMEOUT,
+  loadTimeout: NIGHTMARE_ACTION_TIMEOUT,
+  executionTimeout: NIGHTMARE_ACTION_TIMEOUT,
+  // This one decides whether nightmarejs actually opens a window for the browser it tests in
+  show: process.env.ELECTRON_SHOW_DISPLAY === '1',
+};

--- a/__tests__/end-to-end/e2e-constants.js
+++ b/__tests__/end-to-end/e2e-constants.js
@@ -1,0 +1,1 @@
+export const SIMPLE_TEST_TIMEOUT = 10 * 1000;

--- a/__tests__/end-to-end/e2e-utilities.js
+++ b/__tests__/end-to-end/e2e-utilities.js
@@ -1,27 +1,8 @@
-import Nightmare from 'nightmare';
-
-export function testPathServersideRender(host, path, name, code = 200) {
-  const nightmare = new Nightmare();
-  it(`renders ${name} page correctly`, () => {
-    expect.assertions(1);
-    return nightmare.goto(`${host}${path}`)
-      .end()
-      .then(result => {
-        expect(result.code).toBe(code);
-      });
-  });
-}
-
-export function isVisible(selector, evaluateParent = false) {
-  let element = document.querySelector(selector);
-  if (evaluateParent) {
-    element = element.parentNode;
-  }
-  return (
-    element.style.width !== '0' &&
-    element.style.width !== '0px' &&
-    element.style.height !== '0' &&
-    element.style.height !== '0px' &&
-    element.style.display !== 'none'
-  );
+export function testPathServersideRender(nightmare, host, path, code = 200) {
+  expect.assertions(1);
+  return nightmare.goto(`${host}${path}`)
+    .end()
+    .then(result => {
+      expect(result.code).toBe(code);
+    });
 }

--- a/__tests__/end-to-end/e2e-utilities.js
+++ b/__tests__/end-to-end/e2e-utilities.js
@@ -11,7 +11,3 @@ export function testPathServersideRender(host, path, name, code = 200) {
       });
   });
 }
-
-export const SIMPLE_TEST_TIMEOUT = 10 * 1000;
-export const GAZELLE_HOST = 'http://localhost:3000';
-export const ADMIN_HOST = 'http://localhost:4000';

--- a/__tests__/end-to-end/e2e-utilities.js
+++ b/__tests__/end-to-end/e2e-utilities.js
@@ -11,3 +11,17 @@ export function testPathServersideRender(host, path, name, code = 200) {
       });
   });
 }
+
+export function isVisible(selector, evaluateParent = false) {
+  let element = document.querySelector(selector);
+  if (evaluateParent) {
+    element = element.parentNode;
+  }
+  return (
+    element.style.width !== '0' &&
+    element.style.width !== '0px' &&
+    element.style.height !== '0' &&
+    element.style.height !== '0px' &&
+    element.style.display !== 'none'
+  );
+}

--- a/__tests__/end-to-end/gazelle-tests/e2e-gazelle-constants.js
+++ b/__tests__/end-to-end/gazelle-tests/e2e-gazelle-constants.js
@@ -1,0 +1,1 @@
+export const HOST = 'http://localhost:3000';

--- a/__tests__/end-to-end/gazelle-tests/serverside-rendering.test.js
+++ b/__tests__/end-to-end/gazelle-tests/serverside-rendering.test.js
@@ -1,4 +1,6 @@
-import { testPathServersideRender, SIMPLE_TEST_TIMEOUT, GAZELLE_HOST as HOST } from '../utilities';
+import { testPathServersideRender } from '__tests__/end-to-end/e2e-utilities';
+import { SIMPLE_TEST_TIMEOUT } from '__tests__/end-to-end/e2e-constants';
+import { HOST } from './e2e-gazelle-constants';
 
 jest.setTimeout(SIMPLE_TEST_TIMEOUT);
 

--- a/__tests__/end-to-end/gazelle-tests/serverside-rendering.test.js
+++ b/__tests__/end-to-end/gazelle-tests/serverside-rendering.test.js
@@ -1,24 +1,65 @@
+import Nightmare from 'nightmare';
+
 import { testPathServersideRender } from '__tests__/end-to-end/e2e-utilities';
-import { SIMPLE_TEST_TIMEOUT } from '__tests__/end-to-end/e2e-constants';
+import { SIMPLE_TEST_TIMEOUT, NIGHTMARE_CONFIG } from '__tests__/end-to-end/e2e-constants';
 import { HOST } from './e2e-gazelle-constants';
 
 jest.setTimeout(SIMPLE_TEST_TIMEOUT);
 
 describe('The Gazelle server side rendering', () => {
-  testPathServersideRender(HOST, '', 'front');
-  testPathServersideRender(HOST, '/team', 'team');
-  testPathServersideRender(HOST, '/archives', 'archive');
-  testPathServersideRender(HOST, '/about', 'about');
-  testPathServersideRender(HOST, '/ethics', 'code of ethics');
-  testPathServersideRender(HOST, '/category/news', 'category');
-  testPathServersideRender(HOST, '/issue/100', 'non-default issue');
-  testPathServersideRender(HOST, '/search?q=abu%20dhabi', 'search');
-  testPathServersideRender(
-    HOST,
-    '/issue/100/letters/letter-from-the-editors-celebrating-100-issues',
-    'article'
+  let nightmare = null;
+  beforeEach(() => {
+    nightmare = new Nightmare(NIGHTMARE_CONFIG);
+  });
+
+  afterEach(() => {
+    // Kill the nightmare instance, this won't make a difference if everything worked as expected
+    // but if we don't have it when something doesn't go as unexpected it can make jest hang
+    // and not terminate
+    nightmare.halt();
+  });
+
+  it('renders front page correctly', () => testPathServersideRender(nightmare, HOST, ''));
+  it('renders team page correctly', () => testPathServersideRender(nightmare, HOST, '/team'));
+  it(
+    'renders archive page correctly',
+    () => testPathServersideRender(nightmare, HOST, '/archives')
   );
-  testPathServersideRender(HOST, '/author/khadeeja-farooqui', 'author');
+  it(
+    'renders about page correctly',
+    () => testPathServersideRender(nightmare, HOST, '/about')
+  );
+  it(
+    'renders code of ethics page correctly',
+    () => testPathServersideRender(nightmare, HOST, '/ethics')
+  );
+  it(
+    'renders category page correctly',
+    () => testPathServersideRender(nightmare, HOST, '/category/news')
+  );
+  it(
+    'renders non-default issue page correctly',
+    () => testPathServersideRender(nightmare, HOST, '/issue/100')
+  );
+  it(
+    'renders search page correctly',
+    () => testPathServersideRender(nightmare, HOST, '/search?q=abu%20dhabi')
+  );
+  it(
+    'renders article page correctly',
+    () => testPathServersideRender(
+      nightmare,
+      HOST,
+      '/issue/100/letters/letter-from-the-editors-celebrating-100-issues'
+    )
+  );
+  it(
+    'renders author page correctly',
+    () => testPathServersideRender(nightmare, HOST, '/author/khadeeja-farooqui')
+  );
   // This should definitely return a 404 but it isn't implemented right now so we'll make it a todo
-  testPathServersideRender(HOST, '/this/path/should/not/exist', 'not found', 200);
+  it(
+    'renders not found page correctly',
+    () => testPathServersideRender(nightmare, HOST, '/this/path/should/not/exist', 200)
+  );
 });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node ./build/server.js",
     "build-production": "./node_modules/.bin/webpack -p --config ./webpack.production.config.js --bail",
     "build-beta": "./node_modules/.bin/webpack -p --config ./webpack.beta.config.js --bail",
+    "build-emulate-ci": "CI=true CIRCLECI=true npm run build-production",
     "test:unit": "jest --testPathPattern='.*__tests__/(?!end-to-end/).*\\.test\\.js'",
     "test:e2e": "jest --testPathPattern='__tests__/end-to-end/.*\\.test\\.js'",
     "lint": "eslint --max-warnings 0 '{src,__tests__}/**/*.{js,jsx}'",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-beta": "./node_modules/.bin/webpack -p --config ./webpack.beta.config.js --bail",
     "build-emulate-ci": "CI=true CIRCLECI=true npm run build-production",
     "test:unit": "jest --testPathPattern='.*__tests__/(?!end-to-end/).*\\.test\\.js'",
-    "test:e2e": "jest --testPathPattern='__tests__/end-to-end/.*\\.test\\.js'",
+    "test:e2e": "jest --testPathPattern='__tests__/end-to-end/.*\\.test\\.js' --runInBand",
     "lint": "eslint --max-warnings 0 '{src,__tests__}/**/*.{js,jsx}'",
     "precommit": "npm run lint && npm run test:unit"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     ],
     "moduleDirectories": [
       "node_modules",
-      "./src"
+      "./src",
+      "."
     ]
   },
   "repository": {

--- a/scripts/circleci/run-end-to-end-tests.sh
+++ b/scripts/circleci/run-end-to-end-tests.sh
@@ -3,9 +3,7 @@
 # Run our server
 cd ~/gazelle-server
 
-npm start &> /dev/null &
-
-SERVER_PID=$(echo $!)
+forever start build/server.js &> /dev/null
 
 echo "Gazelle server started"
 
@@ -61,7 +59,8 @@ EXIT_CODE=$(echo $?)
 # Cleanup
 echo "Tests finished, starting cleanup"
 
-kill $SERVER_PID
+forever stopall
+
 kill $GHOST_PID
 kill $SCREEN_PID
 

--- a/src/components/editor/EditorAppController.jsx
+++ b/src/components/editor/EditorAppController.jsx
@@ -228,11 +228,13 @@ export default class EditorAppController extends BaseComponent {
             open={this.state.restartPasswordModalOpen}
             actions={[
               <FlatButton
+                id="restart-server-password-cancel"
                 label="Cancel"
                 onClick={this.toggleRestartPasswordModal}
               />,
               <FlatButton
                 label="Submit"
+                id="restart-server-password-submit"
                 onClick={this.restartServer}
                 disabled={this.state.currentlyRestarting}
               />,
@@ -242,6 +244,7 @@ export default class EditorAppController extends BaseComponent {
               ref={this.assignPasswordRef}
               value={this.state.restartPasswordValue}
               floatingLabelText="Input Password"
+              id="restart-server-password-input"
               type="password"
               onChange={this.fieldUpdaters.restartPassword}
               onKeyUp={this.handleRestartPasswordEnter}

--- a/src/components/editor/EditorAppController.jsx
+++ b/src/components/editor/EditorAppController.jsx
@@ -102,28 +102,33 @@ export default class EditorAppController extends BaseComponent {
 
   render() {
     const bodyStyle = { transition: 'margin-left 450ms cubic-bezier(0.23, 1, 0.32, 1)' };
+    const APP_ID = 'app';
+    const HEADER_ID = `${APP_ID}-header`;
     if (this.isLoggedIn()) { bodyStyle.marginLeft = 256; }
 
     const LoggedIn = () => (
       <IconMenu
         iconButtonElement={
-          <IconButton><MoreVertIcon /></IconButton>
+          <IconButton id={`${HEADER_ID}-menu-button`}><MoreVertIcon /></IconButton>
         }
         targetOrigin={{ horizontal: 'right', vertical: 'top' }}
         anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
       >
         <MenuItem
+          id={`${HEADER_ID}-restart-button`}
           primaryText="Restart Server"
           onClick={this.restartServer}
           style={{ color: '#C62828' }}
         />
         <MenuItem
+          id={`${HEADER_ID}-refresh-ghost-button`}
           primaryText="Refresh Ghost Data"
           onClick={this.resetGhostInfo}
           disabled
         />
         <Divider />
         <MenuItem
+          id={`${HEADER_ID}-sign-out-button`}
           primaryText="Sign out"
           onClick={this.signOut}
         />
@@ -132,8 +137,9 @@ export default class EditorAppController extends BaseComponent {
 
     return (
       <MuiThemeProvider>
-        <div className="mainContainer">
+        <div id={APP_ID} className="mainContainer">
           <AppBar
+            id={HEADER_ID}
             title={"Editor Tools"}
             iconElementRight={this.isLoggedIn() ?
               <LoggedIn /> :

--- a/src/components/editor/EditorAuthorController.jsx
+++ b/src/components/editor/EditorAuthorController.jsx
@@ -234,9 +234,10 @@ export default class EditorAuthorController extends FalcorController {
   }
 
   render() {
+    const ID = 'author-editor';
     if (this.state.ready) {
       if (!this.state.data) {
-        return <div><p>No authors match the slug given in the URL</p></div>;
+        return <div id={ID}><p>No authors match the slug given in the URL</p></div>;
       }
 
       let changedStateMessage;
@@ -261,7 +262,7 @@ export default class EditorAuthorController extends FalcorController {
           autoScrollBodyContent
           onRequestClose={this.handleDialogClose}
         >
-          <div style={styles.authorProfile}>
+          <div id={ID} style={styles.authorProfile}>
             <h3>Author Profile: {this.state.name}</h3>
             <Divider />
             <form onSubmit={this.handleSaveChanges}>

--- a/src/components/editor/EditorAuthorListController.jsx
+++ b/src/components/editor/EditorAuthorListController.jsx
@@ -102,15 +102,16 @@ export default class EditorAuthorListController extends FalcorController {
   }
 
   render() {
+    const ID = 'author-list';
     if (this.state.ready) {
       return (
-        <div>
+        <div id={ID}>
           <h1>Authors</h1>
           <Divider />
           <Paper style={styles.paper} zDepth={2}>
             <Tabs>
               <Tab label="EDIT" icon={<ModeEdit />}>
-                <div style={styles.tabs}>
+                <div id={`${ID}-edit-tab`} style={styles.tabs}>
                   <h2>Edit Author</h2>
                   <Divider />
                   <EditorSearchBar
@@ -123,7 +124,7 @@ export default class EditorAuthorListController extends FalcorController {
                 </div>
               </Tab>
               <Tab label="ADD NEW" icon={<PersonAdd />}>
-                <div style={styles.tabs}>
+                <div id={`${ID}-add-new-tab`} style={styles.tabs}>
                   <h2>Add New Author</h2>
                   <Divider />
                   <form

--- a/src/components/editor/EditorLogin.jsx
+++ b/src/components/editor/EditorLogin.jsx
@@ -53,7 +53,7 @@ export default class Login extends BaseComponent {
 
   render() {
     return (
-      <div>
+      <div id="login-page">
         <form onSubmit={this.handleSubmit}>
           <TextField
             name="password"

--- a/src/components/editor/EditorSearchBar.jsx
+++ b/src/components/editor/EditorSearchBar.jsx
@@ -106,9 +106,11 @@ export default class EditorSearchBar extends BaseComponent {
   }
 
   render() {
+    const searchResultClass = 'search-bar-result';
+    const searchBarClass = 'search-bar';
     if (this.props.mode === 'articles') {
       return (
-        <div>
+        <div className={`${searchBarClass} ${searchBarClass}-articles`}>
           <TextField
             floatingLabelText="Search for Articles"
             hintText="Article"
@@ -131,7 +133,7 @@ export default class EditorSearchBar extends BaseComponent {
                     textShown += ` - ${date}`;
                   }
                   return (
-                    <div key={article.slug}>
+                    <div className={searchResultClass} key={article.slug}>
                       {/* eslint-disable react/jsx-no-bind */}
                       <MenuItem
                         primaryText={textShown}
@@ -149,7 +151,7 @@ export default class EditorSearchBar extends BaseComponent {
       );
     } else if (this.props.mode === 'authors') {
       return (
-        <div>
+        <div className={`${searchBarClass} ${searchBarClass}-authors`}>
           <TextField
             floatingLabelText="Search for Authors"
             hintText="Author"
@@ -160,7 +162,7 @@ export default class EditorSearchBar extends BaseComponent {
             <Menu style={{ width: 200 }}>
               {
                 this.state.searchSuggestions.map((author) => (
-                  <div key={author.slug}>
+                  <div className={searchResultClass} key={author.slug}>
                     {/* eslint-disable react/jsx-no-bind */}
                     <MenuItem
                       primaryText={author.name}

--- a/webpack.beta.config.js
+++ b/webpack.beta.config.js
@@ -35,6 +35,7 @@ module.exports = [{
     modulesDirectories: [
       'node_modules',
       './src/',
+      '.',
     ],
     extensions: ['', '.js', '.jsx'],
   },
@@ -103,6 +104,7 @@ module.exports = [{
     modulesDirectories: [
       'node_modules',
       './src/',
+      '.',
     ],
     extensions: ['', '.js', '.jsx'],
   },
@@ -145,6 +147,7 @@ module.exports = [{
     modulesDirectories: [
       'node_modules',
       './src/',
+      '.',
     ],
     extensions: ['', '.js', '.jsx'],
   },

--- a/webpack.beta.config.js
+++ b/webpack.beta.config.js
@@ -49,6 +49,7 @@ module.exports = [{
         'NODE_ENV': '"beta"', // compiles React as beta build
 	      'MAIN_PORT': 8003, // we use a reverse proxy to forward this to port 80 of editor.thegazelle.org
         'EDITOR_PORT': 8004,
+        'ROOT_DIRECTORY': JSON.stringify(__dirname),
       },
     }),
     new webpack.optimize.UglifyJsPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,11 @@ module.exports = [{
     new ExtractTextPlugin('./static/build/main.css', {
       allChunks: true,
     }),
+    new webpack.DefinePlugin({
+      'process.env': {
+        'ROOT_DIRECTORY': JSON.stringify(__dirname),
+      },
+    }),
   ],
 
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,7 @@ module.exports = [{
     modulesDirectories: [
       'node_modules',
       './src/',
+      '.',
     ],
     extensions: ['', '.js', '.jsx'],
   },
@@ -100,6 +101,7 @@ module.exports = [{
     modulesDirectories: [
       'node_modules',
       './src/',
+      '.',
     ],
     extensions: ['', '.js', '.jsx'],
   },
@@ -148,6 +150,7 @@ module.exports = [{
     modulesDirectories: [
       'node_modules',
       './src/',
+      '.',
     ],
     extensions: ['', '.js', '.jsx']
   },

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -53,6 +53,7 @@ module.exports = [{
         'EDITOR_PORT': 8002,
         'CI': JSON.stringify(process.env.CI),
         'CIRCLECI': JSON.stringify(process.env.CIRCLECI),
+        'ROOT_DIRECTORY': JSON.stringify(__dirname),
       },
     }),
     new webpack.optimize.UglifyJsPlugin({

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -10,6 +10,8 @@ var nodeModules = {}
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var cssnext = require('postcss-cssnext');
 
+var isCI = process.env.CI === 'true' && process.env.CIRCLECI === 'true';
+
 Fs.readdirSync('node_modules').forEach(function (module) {
   if (module !== '.bin') {
     nodeModules[module] = true
@@ -94,6 +96,7 @@ module.exports = [{
   postcss: function () {
     return [cssnext];
   },
+  devtool: isCI ? 'source-map' : undefined,
 }, {
   target: 'web',
   entry: './src/client-scripts/gazelle-client.js',
@@ -135,6 +138,7 @@ module.exports = [{
       },
     ],
   },
+  devtool: isCI ? 'source-map' : undefined,
 },
 {
   target: 'web',
@@ -172,4 +176,5 @@ module.exports = [{
       },
     ],
   },
+  devtool: isCI ? 'source-map' : undefined,
 }]

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -37,6 +37,7 @@ module.exports = [{
     modulesDirectories: [
       'node_modules',
       './src/',
+      '.',
     ],
     extensions: ['', '.js', '.jsx'],
   },
@@ -108,6 +109,7 @@ module.exports = [{
     modulesDirectories: [
       'node_modules',
       './src/',
+      '.',
     ],
     extensions: ['', '.js', '.jsx'],
   },
@@ -151,6 +153,7 @@ module.exports = [{
     modulesDirectories: [
       'node_modules',
       './src/',
+      '.',
     ],
     extensions: ['', '.js', '.jsx'],
   },


### PR DESCRIPTION
Okay, so this is a bit of a big one! I really tried making this very high quality code, so that it's a good example for future devs to base this off, so feel free to be super critical about anything style / overall structure related as I want this to be top notch.

So in big terms, what this PR has introduced is:
- E2E tests for the header, including signing out and restarting the server
- The restart server interface was ported from `window.prompt` to a MaterialUI Dialog because it isn't straight forward to interact with `window.prompt` with `nightmarejs` and I want to get away from all the ugly `window.alert` and `window.prompt` at some point anyway
- Refactored the workings of the restart server command
- Added E2E tests for the login screen
- Added E2E tests for the `AuthorList` component
- Final refactors and restructures of files and directories for the `__tests__/end-to-end` folder
- Added some HTML ids and classes for easier access to elements with CSS selectors using `nightmarejs`
- Wrote a Wiki entry on developing on our E2E tests: [link](https://github.com/thegazelle-ad/gazelle-server/wiki/Developing-End-To-End-(E2E)-tests)