### PR TITLE
Make config imports based on root

### DIFF
--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -2,7 +2,7 @@
 // We disable camelcase here due to SQL naming conventions
 import knex from 'knex';
 import stable from 'stable';
-import databaseConfig from 'lib/../../config/database.config';
+import databaseConfig from 'config/database.config';
 import { mapGhostNames } from 'lib/falcor/falcor-utilities';
 import _ from 'lodash';
 import { formatDate, formatDateTime } from 'lib/utilities';

--- a/src/lib/ghost-api.js
+++ b/src/lib/ghost-api.js
@@ -1,5 +1,5 @@
 import http from 'http';
-import ghostConfig from 'lib/../../config/ghost.config';
+import ghostConfig from 'config/ghost.config';
 
 export function ghostArticleQuery(params) {
   return new Promise((resolve) => {

--- a/src/server-code/admin-server.js
+++ b/src/server-code/admin-server.js
@@ -10,11 +10,10 @@ import s3 from 's3';
 // Needed for receiving the multi-part file upload
 import multer from 'multer';
 // Our own custom config
-import s3Config from '../../config/s3.config.js';
+import s3Config from 'config/s3.config.js';
 
 /* Helper libraries */
 import fs from 'fs';
-import path from 'path';
 import { exec } from 'child_process';
 // Helps us parse post requests from falcor
 import bodyParser from 'body-parser';
@@ -105,7 +104,7 @@ export default function runAdminServer(serverFalcorModel) {
   });
 
   /* Image Uploader */
-  const uploadDir = path.join(__dirname, '../../tmp');
+  const uploadDir = `${process.env.ROOT_DIRECTORY}/tmp`;
 
   if (!fs.existsSync(uploadDir)) {
     fs.mkdirSync(uploadDir);


### PR DESCRIPTION
Just a small uglyness in the imports I introduced a while back, and while working on the E2E tests I added the root directory to modules Webpack resolves anyway, so changed the paths to be prettier.