### PR TITLE
Migrate Wiki to Repo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,6 @@
 
 The documentation consists of three parts:
 
-1. [DevOps](./dev-ops/README.md): If you are not a lead engineer in charge of setting up the actual production servers you should never need to look at this. If you ever are in need of setting up the server, this is where you should look though.
-2. [Dev Environment](./dev-environment/README.md): All the guides for setting up your dev environment. Both the crucial [Setting up your Dev Environment](./dev-environment/setting-up-dev-environment.md) guide, which everyone should check out, and more optional but helpful ones such as how to setup debuggers
-3. [Guides](./guides/README.md): Miscellaneous guides that are good to check out and at least be aware of what are in them. This is for example where we keep our guide for how to develop E2E tests for The Gazelle.
+1. [DevOps](./dev-ops): If you are not a lead engineer in charge of setting up the actual production servers you should never need to look at this. If you ever are in need of setting up the server, this is where you should look though.
+2. [Dev Environment](./dev-environment): All the guides for setting up your dev environment. Both the crucial [Setting up your Dev Environment](./dev-environment/setting-up-dev-environment.md) guide, which everyone should check out, and more optional but helpful ones such as how to setup debuggers.
+3. [Guides](./guides): Miscellaneous guides that are good to check out and at least be aware of what are in them. This is for example where we keep our guide for how to develop E2E tests for The Gazelle.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,5 +3,5 @@
 The documentation consists of three parts:
 
 1. [DevOps](./dev-ops/README.md): If you are not a lead engineer in charge of setting up the actual production servers you should never need to look at this. If you ever are in need of setting up the server, this is where you should look though.
-2. [Dev Environment](./dev-environment/README.md): All the guides for setting up your dev environment. Both the crucial [Setting up your Dev Environment] guide(./dev-environment/setting-up-dev-environment.md), which everyone should check out, and more optional but helpful ones such as how to setup debuggers
+2. [Dev Environment](./dev-environment/README.md): All the guides for setting up your dev environment. Both the crucial [Setting up your Dev Environment](./dev-environment/setting-up-dev-environment.md) guide, which everyone should check out, and more optional but helpful ones such as how to setup debuggers
 3. [Guides](./guides/README.md): Miscellaneous guides that are good to check out and at least be aware of what are in them. This is for example where we keep our guide for how to develop E2E tests for The Gazelle.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Documentation Index
+
+The documentation consists of three parts:
+
+1. [DevOps](./dev-ops/README.md): If you are not a lead engineer in charge of setting up the actual production servers you should never need to look at this. If you ever are in need of setting up the server, this is where you should look though.
+2. [Dev Environment](./dev-environment/README.md): All the guides for setting up your dev environment. Both the crucial [Setting up your Dev Environment guide](./dev-environment/setting-up-dev-environment.md), which everyone should check out, and more optional but helpful ones such as how to setup debuggers
+3. [Guides](./guides/README.md): Miscellaneous guides that are good to check out and at least be aware of what are in them. This is for example where we keep our guide for how to develop E2E tests for The Gazelle.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,5 +3,5 @@
 The documentation consists of three parts:
 
 1. [DevOps](./dev-ops/README.md): If you are not a lead engineer in charge of setting up the actual production servers you should never need to look at this. If you ever are in need of setting up the server, this is where you should look though.
-2. [Dev Environment](./dev-environment/README.md): All the guides for setting up your dev environment. Both the crucial [Setting up your Dev Environment guide](./dev-environment/setting-up-dev-environment.md), which everyone should check out, and more optional but helpful ones such as how to setup debuggers
+2. [Dev Environment](./dev-environment/README.md): All the guides for setting up your dev environment. Both the crucial [Setting up your Dev Environment] guide(./dev-environment/setting-up-dev-environment.md), which everyone should check out, and more optional but helpful ones such as how to setup debuggers
 3. [Guides](./guides/README.md): Miscellaneous guides that are good to check out and at least be aware of what are in them. This is for example where we keep our guide for how to develop E2E tests for The Gazelle.

--- a/docs/dev-environment/README.md
+++ b/docs/dev-environment/README.md
@@ -1,0 +1,5 @@
+# Index for Dev Environment Guides
+
+This folder contains the following guides:
+1. [Setting up your Dev Environment](./setting-up-dev-environment.md): Everyone should read this, this is how to setup your dev environment
+2. [Setting up Debuggers](./setting-up-debuggers.md): Debuggers are immensely helpful tools during development, this guide outlines some possible ways to setup debuggers for both the clientside JS and the server (feel free to add others if you use a different but also good setup)

--- a/docs/dev-environment/README.md
+++ b/docs/dev-environment/README.md
@@ -1,5 +1,5 @@
 # Index for Dev Environment Guides
 
 This folder contains the following guides:
-1. [Setting up your Dev Environment](./setting-up-dev-environment.md): Everyone should read this, this is how to setup your dev environment
-2. [Setting up Debuggers](./setting-up-debuggers.md): Debuggers are immensely helpful tools during development, this guide outlines some possible ways to setup debuggers for both the clientside JS and the server (feel free to add others if you use a different but also good setup)
+1. [Setting Up Your Dev Environment](./setting-up-dev-environment.md): Everyone should read this, this is how to setup your dev environment
+2. [Setting Up Debuggers](./setting-up-debuggers.md): Debuggers are immensely helpful tools during development, this guide outlines some possible ways to setup debuggers for both the clientside JS and the server (feel free to add others if you use a different but also good setup)

--- a/docs/dev-environment/setting-up-debuggers.md
+++ b/docs/dev-environment/setting-up-debuggers.md
@@ -1,0 +1,34 @@
+# Server code
+
+Feel free to add instructions for other editors/IDEs
+
+## VS Code
+
+Simply add the following `launch.json` file to your debugger config:
+
+```json5
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceFolder}/src/index.js",
+      "sourceMaps": true,
+      "outFiles": [
+        "build/server.js",
+      ]
+    }
+  ]
+}
+```
+
+And you should now be able to set all those lovely breakpoints and enjoy the luxury of the VS code debugger!
+
+# Client (browser) code
+
+Chrome DevTools all the way! See [this official guide](https://developers.google.com/web/tools/chrome-devtools/) for some instructions

--- a/docs/dev-environment/setting-up-dev-environment.md
+++ b/docs/dev-environment/setting-up-dev-environment.md
@@ -1,0 +1,161 @@
+If you encounter unexpected errors during setup, or later during usage, see the `Frequently Encountered Errors` section at the bottom of this page.
+
+Also, if not obvious, all instructions in this setup guide assume that you have already cloned [this repo](https://github.com/thegazelle-ad/gazelle-server) which the wiki is located in, and that your current working directory is this repo.
+
+# Install
+
+Make sure you have NodeJS and npm installed
+
+[Install nodejs and npm via nvm](https://github.com/creationix/nvm)
+
+> **IMPORTANT**: For this, the main, repo we use **node v9.3.0** and **npm 5.6.0** (it's important not to use npm 5.5.x which may come as the default with node v9.3.0 as npm 5.5.x has a bug that breaks on node 9.3.0). Use any other versions at your own peril.
+
+Then install dependencies locally
+
+```
+npm install
+```
+
+# Connect to Ghost and Database
+To get Ghost and the database up and running on your server first clone [this repo](https://github.com/thegazelle-ad/database-and-ghost-blog-server) to your computer (outside the main repo) and follow the readme to get it set up.
+
+> NOTE: The README in that repo assumes you have cloned that repo and have your working directory set to be that repo. When you're done and return here we again assume you have your working directory set to this repository
+
+When this is done copy database.config.example.js and ghost.config.example.js (They are both in the config folder) to their non example counterparts, you would do this as follows in bash:
+
+```
+cp config/database.config.example.js config/database.config.js
+cp config/ghost.config.example.js config/ghost.config.js
+```
+
+It is important that you name them exactly as specified above.
+
+Now change the config as necessary. The most important is the host and port of your Ghost blog (you can see where it is running in the ghost config.js file in the database-and-ghost repo), and the password and database name of the database being used in database.config.js. In special situations other things might be relevant as well.
+
+When this is done run
+
+`./scripts/get-ghost-config.sh`
+
+which will fetch the user and password from the database for the Ghost API for you and put it in the ghost.config.js file.
+
+Your repo should now be connected successfully to your local database and Ghost blog.
+
+# Amazon S3
+
+For development purposes all you need for Amazon S3 is a dummy config file as while in dev mode the server doesn't actually try connecting to Amazon's servers
+
+`cp config/s3.config.example.js config/s3.config.js`
+
+# Run build tool
+
+For single build
+
+```
+npm run build
+```
+
+Or in watch mode (for active development)
+
+```
+npm run build:watch # or npm run build -- -w
+```
+
+You will find the results in the `./build/` and `./static/build/` folders (not pushed to git)
+
+Make sure to keep watching the build window, in case there is
+a syntax error or something else preventing builds. Your code will not
+recompile if there are build errors
+
+# Run Ghost Blog
+
+Remember to run your Ghost blog before running the server so you can access the article data by running:
+```
+nvm use 4.2
+npm start --production
+```
+in the database-and-ghost repository.
+
+# Run server
+
+You need to re-run the server to isomorphically serve the latest
+version. However, if you are just changing frontend, you can choose
+to not restart the server on change, and just refresh the page, and the frontend code will still
+be up to date time. The isomorphism will be broken, but it's not
+important for development.
+
+```
+npm start # or node build/server.js
+```
+
+If you are not restarting the server you may have to disable caching for refresh to work. There's an option in Chrome
+dev tools to do this.
+
+# Convenience setup
+
+To manage your node versions it can be nice setting up some scripts, one way of doing that is using `virtualenv` and `virtualenvwrapper` that is normally used for Python development but can still be a nice tool. If you install these two packages a nice setup can be created by making two virtual environments as follows:
+
+```
+mkvirtualenv -a path/to/gazelle-server gazelle_server
+mkvirtualenv -a path/to/database-and-ghost-blog-server gazelle_ghost
+```
+
+Where the last argument is the names of the virtual environments.
+
+You can now setup some scripts to run when you `activate` these virtual environments. By adding the following to `~/.virtualenvs/gazelle_server/bin/postactivate`:
+
+```bash
+nvm use 9.3.0
+```
+
+and to `~/.virtualenvs/gazelle_server/bin/postactivate`:
+
+```bash
+nvm use 4.2
+npm start --production # This is just personal preference as I only ever visit this repo to start the ghost blog
+```
+
+Now when you write `workon gazelle_server` from any directory your current working directory will move to the `gazelle-server` repo and the correct node version will be started for you.
+
+When you write `workon gazelle_ghost` your current working directory will then move to the `database-and-ghost-blog-server` repo, the node version will be correctly changed and the server will start.
+
+> NOTE: `workon` also has autocomplete functionality which is a nice detail
+
+To exit any of these virtual environments at any point (though unless you're actually writing python the virtual env itself won't actually do anything, we're just using it as a nice way to write some postactivate scripts), just run `deactivate`.
+
+# Note on linters and tests
+
+Linting is included in webpack, so when building your code while developing check the linting errors to make sure you're following the recommended coding style.
+
+We also have precommit hooks setup, so every time you make a commit both the linter and all relevant unit tests will be run to check you didn't break anything in your commit. If you ever need to make a temporary commit for any reason that either breaks the linter or tests (sometimes you need to save work for for example switching a branch and your current changes may be a work in progress) just use the `--no-verify` option with `git commit`.
+
+If you ever want to run all the unit tests simply run
+
+```
+npm run test:unit
+```
+
+and for linting
+
+```
+npm run lint
+```
+
+# Fun Facts
+
+## Isomorphism
+
+This is served isomorphically. That means the initial render is
+on the server, then the identical code is served to the client, and
+the web browser client does subsequent renders. If you want to know
+more about what isomorphism is, here's an article that might help:
+
+[What is an isomorphic application?](https://www.lullabot.com/articles/what-is-an-isomorphic-application)
+
+# Frequently Encountered Issues
+
+* If you're unable to get the database running and receive the error `Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)`, this means that the database server didn't automatically run on startup, run the command `mysqld &` to start the database server. This seems to happen often on MacOS
+
+* MySQL error 1045 (you don't know what password was set)<br />
+For Ubuntu - Download and Install synaptic package manager.
+Using synaptic, remove all instances of mariadb. 
+Then, follow this guide and completely remove MySQL. https://askubuntu.com/questions/640899/how-do-i-uninstall-mysql-completely. Reinstall mariadb and make sure to set a different password this time when prompted. Hopefully the error does not repeat.

--- a/docs/dev-ops/README.md
+++ b/docs/dev-ops/README.md
@@ -1,0 +1,5 @@
+# Index for DevOps Guides
+
+This folder contains the following guides:
+1. [Setting up our Server](./setting-up-server.md): The guide to setup the production server
+2. [Staging Specific Server Setup](./staging-specific-server-setup.md): This guide references to the parts of the above guide to use, and then adds on specific things to setting up a staging server if you're running them on two different servers.

--- a/docs/dev-ops/README.md
+++ b/docs/dev-ops/README.md
@@ -1,5 +1,5 @@
 # Index for DevOps Guides
 
 This folder contains the following guides:
-1. [Setting up our Server](./setting-up-server.md): The guide to setup the production server
+1. [Setting Up Our Server](./setting-up-server.md): The guide to setting up the production server
 2. [Staging Specific Server Setup](./staging-specific-server-setup.md): This guide references to the parts of the above guide to use, and then adds on specific things to setting up a staging server if you're running them on two different servers.

--- a/docs/dev-ops/setting-up-server.md
+++ b/docs/dev-ops/setting-up-server.md
@@ -1,0 +1,168 @@
+Firstly, just to reiterate, this is the guide to setup The Gazelle's server for production, you only need this if you are handling the main DevOps for The Gazelle, this is not related to normal development.
+
+# Creating the server
+At the time of writing we are using Digital Ocean. To setup a new Droplet you can follow [this guide](https://www.digitalocean.com/community/tutorials/how-to-create-your-first-digitalocean-droplet). We are currently using one of the Ubuntu 16.04 "Flexible Droplets" with 2GB RAM and 2 vCPUs located in London.
+
+# Initial Server Setup
+Here is [a really good guide](https://www.digitalocean.com/community/tutorials/initial-server-setup-with-ubuntu-16-04) for setting up an Ubuntu 16.04 server initially (which is what we use), this is the recommended guide to follow regardless of whether the current provider is Digital Ocean or not. Remember to also follow the link about "common UFW operations" at the bottom to allow http(s) connections and possibly database connections from the staging server.
+
+It is also handy to run 
+
+```
+sudo apt update
+```
+
+for the future installations we'll do.
+
+# Setting up git and connecting to Github
+We use a Github "Machine User" as [described here](https://developer.github.com/v3/guides/managing-deploy-keys/#machine-users) with the username `gazelle-deployment-bot`. The login credentials can be found on the `nerds@thegazelle.org` LastPass account (which the lead engineers have access to). The `gazelle-deployment-bot` is an outside collaborator to the `thegazelle-ad` organization with read-only access to the repos it needs to use. Remember to add it as an outside collaborator to any new repos which may be needed, but only read-only as code should never be edited from the server (see [this guide](https://help.github.com/articles/adding-outside-collaborators-to-repositories-in-your-organization/), but as long as all the repos are public adding it as an outside collaborator shouldn't even be necessary).
+
+Now install git
+
+```
+sudo apt install git
+```
+
+and then setup git
+
+```
+git config --global user.name "Gazelle Deployment Bot"
+git config --global user.email nerds@thegazelle.org
+# This one is just personal preference
+git config --global core.editor vim
+```
+
+Then setup SSH on the server by first adding an ssh key as [described here](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/), and then [add the key](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/) to the Github account of `gazelle-deployment-bot`.
+
+# Install necessary programs
+First [install nvm](https://github.com/creationix/nvm) and install the needed versions of node and npm (order is important as we want forever and npm v5.6.0 paired with node v9.3.0)
+
+```
+nvm install 9.3.0
+npm install -g npm@5.6.0
+npm install -g forever
+nvm install 4.2
+```
+
+> Note: Since you install `9.3.0` first, this will become the nvm default on startup (which is intended), but since you install `4.2` last that will be your active version, therefore, if you're doing all this in one go, remember to run `nvm use 9.3.0` (or `nvm use default` should be equivalent if installed correctly) before installing the main repo where this version is our officially supported one.
+
+You will also need python2 for some of the npm packages to run and it doesn't ship with Ubuntu 16.0.4, you can probably install it in many ways but [here](https://askubuntu.com/a/831075) is a simple guide which basically consists of
+
+```
+sudo apt install python2.7
+sudo apt install python-pip
+sudo apt install python3-pip
+sudo -H python2 -m pip install --upgrade pip
+sudo -H python3 -m pip install --upgrade pip
+```
+
+# Reconfigure timezone
+We run the server on UAE time, the easiest way to reconfigure the timezone is running
+
+```
+sudo dpkg-reconfigure tzdata
+```
+
+Which will take you through an interactive guide so you can set the timezone to `Asia/Dubai` (or Abu Dhabi, but I only found Dubai)
+
+# Install the server
+
+## Setting up simple dev environment
+You just follow [the wiki page for setting up the server](https://github.com/thegazelle-ad/gazelle-server/wiki/Setting-Up-Dev-Environment) up until but not including the build step. Remember to install the `stable` branch for production and `master` for staging. We normally name the main server directory `server` and the ghost + database one `ghost`.
+
+> NOTE: Remember to set the config of the Ghost blog so that the port is 8003 (or to match the Caddy config whatever that is at the moment), and to do this both in `server/config/ghost.config.js` and in `ghost/config.js`
+
+## Production specific config/setup
+
+### Amazon S3
+
+In the dev setup you copied the dummy S3 config file `config/s3.config.js`, when setting up for production we also need actual credentials in that file. If you're simply migrating the server you can just copy the `s3.config.js` file from that server. If you're starting from scratch you'll need to generate a new pair of access keys which you do by going to your Amazon AWS account > My Security Credentials > Access Keys (Access Key ID and Secret Access Key) > Generate new key. And then you simply fill out the config file as is clearly outlined by the object.
+
+### Generating static http error code pages
+In order to not check in a lot of duplicate html pages we have written a short python generator that takes a template and creates specific error pages for each of the 5xx error codes. Generate these pages by simply running `python3 http-error-static-pages/5xx-static-html-generator.py` at the root of the `server` directory.
+
+### Build the source
+
+> NOTE: If you are setting this up on a server with a small amount of RAM you might want to setup swap space first or it might not be sufficient to build source
+
+Now depending on whether you are setting up the staging or production server simply run
+
+```
+npm run build:staging
+```
+
+or 
+
+```
+npm run build:production
+```
+
+in the root of the `server` directory.
+
+# Update DNS
+
+We use Cloudflare as our DNS provider. The lead engineers should have access to the login for it. Simply go here and update the IPs so they match the correct IPs for the production/staging server.
+
+# Setup slack deployment bot
+
+All you should have to do is clone [this repo](https://github.com/thegazelle-ad/slack-deployment-bot) into the home directory of your server and follow the README.
+
+# Setup Swap Space
+
+It is a good idea to setup swap space so that in case a huge load comes in (or we are deploying and therefore building source, Webpack takes up a lot of RAM!) our processes don't simply get killed. [this Digital Ocean guide](https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-16-04) details how to setup swap space. In our current setup on the production server we have bought a 2GB volume (very cheaply) so as to be nice to Digital Ocean and not setup swap space on the SSD and setup a 1.5GB swap file there. As the guide recommends we also changes the `swappiness` to 10 and the `vfs_cache_pressure` to 50.
+
+# Setup deployment resources
+
+Clone [this repo](https://github.com/thegazelle-ad/deployment-resources) to the root directory of your server and follow the instructions in the README.
+
+# Run everything
+
+First we start the main server:
+
+```
+cd ~/server
+forever start --uid "server" build/server.js
+```
+
+Now startup a GNU Screen session (you can find a cheat sheet [here](http://neophob.com/2007/04/gnu-screen-cheat-sheet/), and several tutorials online). We recommend naming the session by for example running `screen -S main`. We also usually use the following `.screenrc` which you are welcome to setup
+
+```
+startup_message off
+term screen-256color
+hardstatus off
+escape ^Ff
+hardstatus alwayslastline
+hardstatus string '%{= kG}[ %{G}%H %{g}][%= %{= kw}%?%-Lw%?%{r}(%{W}%n*%f%t%?(%u)%?%{r})%{w}%?%+Lw%?%?%= %{g}][%{B} %m-%d %{W} %c %{g}]'
+vbell off
+```
+
+Note that if you use the above `.screenrc` the escape key will be `CTRL + f` instead of `CTRL + a`.
+
+Now in the first window start Ghost:
+
+```
+cd ~/ghost
+nvm use 4.2
+npm start --production
+```
+
+Then open another window in the same screen session (`CTRL + f, c`) and start caddy
+
+```
+~/deployment-resources/scripts/run_caddy.sh
+```
+
+And then you can detach from the screen session (`CTRL + f, d`), to ever reattach to it (if you named it main) simply execute `screen -r main`.
+
+# Connect to the CI
+In order to let CircleCI know the IP/user etc. of your servers we need to set some environment variables. These are described as follows:
+
+- `GAZELLE_SERVER_STAGING_USER`: The user we created for the staging Ubuntu server
+- `GAZELLE_SERVER_STAGING_IP`: The IP for the staging Ubuntu server
+- `GAZELLE_SERVER_PRODUCTION_USER`: The user we created for the production Ubuntu server
+- `GAZELLE_SERVER_PRODUCTION_IP`: The IP for the production Ubuntu server
+
+Also remember to add the CI ssh public key to the `.ssh/authorized_keys` file on the server to allow CircleCI to access it
+
+# Done!
+Congratulations! The server should now be setup and running on the relevant domain names, and all dev support such as CI and Slack integration should be working as well! Hope you don't have any stupid bugs to hunt down, and if you do please update this document to help future server admins.

--- a/docs/dev-ops/staging-specific-server-setup.md
+++ b/docs/dev-ops/staging-specific-server-setup.md
@@ -1,0 +1,13 @@
+>**ATTENTION**: This is not for normal dev setup, only for setting up the actual staging server, and it is intended to be used in conjunction with https://github.com/thegazelle-ad/gazelle-server/wiki/Setting-Up-The-Server-(DevOps)
+
+This guide is only meant for the case when you are setting up the staging server on a separate machine, if you are setting up both staging and production on the same machine you should be able to follow the guide linked to above, and not read any further.
+
+# Staging specific deviations / additions
+- You don't need to install the Ghost repo at all (this includes installing MariaDB, no need to look at the README of that repo at all)
+- You don't need to setup database backups (assuming this is setup on the production server)
+- You will need to setup a new user on the mysql database of the production server that corresponds to the host of the ip of the staging server (see [this guide](https://support.rackspace.com/how-to/mysql-connect-to-your-database-remotely/)
+- You will need to make mysql listen on your public IP (on the production server), the easiest way is to make it listen to the wildcard IP `0.0.0.0`, you do this by making the `bind-address` in your `my.cnf` file `0.0.0.0`. See [this SO answer](https://stackoverflow.com/a/2485758/5711883) for directions on how to find this file. After changing it you will have to restart mysql which is described how to do in [this SO answer](https://superuser.com/a/282145)
+- You will need to make Ghost listen on the public IP, which again is easiest by making it listen to the wildcard. So in your production server's Ghost repository you should change the `BLOG_HOST` variable in the `config.js` file to `0.0.0.0`
+- You will have to update the `ufw` firewall rules on the production server to allow incoming connections for both mysql and Ghost. You can see how to update it for mysql [here](https://www.digitalocean.com/community/tutorials/ufw-essentials-common-firewall-rules-and-commands#service-mysql). And you should be able to do something very similar by just changing the port number to the port you run Ghost on on the production server (currently 8003)
+
+Other than this you should be able to just follow [the normal guide](https://github.com/thegazelle-ad/gazelle-server/wiki/Setting-Up-The-Server-(DevOps)) and have everything setup so the staging server connects to the main database!

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,4 +1,4 @@
 # Index for Miscellaneous Guides
 
 This folder contains the following guides:
-1. [Developing End to End Tests](./developing-end-to-end-tests.md): A guide that describes how we write and run end to end (E2E) tests locally
+1. [Developing End To End Tests](./developing-end-to-end-tests.md): A guide that describes how we write and run end to end (E2E) tests locally

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,4 @@
+# Index for Miscellaneous Guides
+
+This folder contains the following guides:
+1. [Developing End to End Tests](./developing-end-to-end-tests.md): A guide that describes how we write and run end to end (E2E) tests locally

--- a/docs/guides/developing-end-to-end-tests.md
+++ b/docs/guides/developing-end-to-end-tests.md
@@ -1,0 +1,90 @@
+## API
+This guide is not meant to explain the API of either `jest` nor `nightmare`, but rather the specifics about how we use them in the context of our E2E tests. If you see functions that confuse you in the code, or you want to look up features that could be useful for further development of tests you can check out the [`nightmare` api](https://github.com/segmentio/nightmare#api) or the [`jest` docs](http://facebook.github.io/jest/docs/en/getting-started.html). Another good resource is also the W3's page on [CSS selectors](https://www.w3schools.com/cssref/css_selectors.asp).
+
+## Running E2E tests locally
+The E2E tests are written to be run in our CI environment, so you need to do a bit more than what we do in the [Setting Up](https://github.com/thegazelle-ad/gazelle-server/wiki/Setting-Up) guide in order to run the E2E tests locally.
+
+Firstly you should install `forever` if you haven't already
+```
+npm i -g forever
+```
+
+you should then build our source using the `build-emulate-ci` script instead of a normal build
+```
+npm run build:emulate-ci
+```
+> NOTE: This will take longer than a normal dev build as it's actually the production build with a few environment variables added. It is also not worth putting this into watch mode, but most of the time you shouldn't be needing to recompile this very often as you will mainly be editing the tests and we don't compile them
+
+Now run the Ghost server as usual, but instead of the normal `npm start` for running the server, instead run
+```
+forever start build/server.js
+```
+> NOTE: This will keep the server running in the background until you turn off your computer or you run `forever stopall` (or the specific id but `stopall` is easier). The reason we need forever here is that's how the production server runs it and that's the only way we can test whether restarting the server works + restarting it for various tests.
+
+To stop the server, run
+```
+forever stopall
+```
+or
+```
+forever stop <id>
+```
+and for restart, run
+```
+forever restart all
+```
+or
+```
+forever restart <id>
+```
+
+You can now run the E2E tests via the `test:e2e` script
+```
+npm run test:e2e
+```
+
+## Debugging
+There are a few debugging tricks that are useful to know when writing these automated browser scripts. The first one is running the tests with the `nightmare` debug flag `nightmare*`:
+```
+DEBUG=nightmare* npm run test:e2e
+```
+
+The second one is using our own `ELECTRON_SHOW_DISPLAY` environment variable which will change the shared config all our `nightmare` instances use. This will make the browser window actually show so you can see your tests running which can be very useful to see where it is the website stops reacting as you expect:
+```
+ELECTRON_SHOW_DISPLAY=1 npm run test:e2e
+```
+
+You can of course also run both of these at the same time. 
+
+The last tip is a `jest` tip, which allows you to run just a single test at a time which is nice for debugging (and is especially invaluable if you're using `ELECTRON_SHOW_DISPLAY` as it will all just be a mess otherwise). You can use the `it.only` command in a test file, and then only tests (yes you can do it on several if you want) that have the `.only` suffix will run, it also works with `describe.only` if you want (and there's also a `it.skip`/`describe.skip` but that's usually used more for skipping temporarily broken tests until they get fixed in the future). So you would for example change
+```js
+it('test something', () => expect(something).toBe(somethingElse))
+```
+to
+```js
+it.only('test something', () => expect(something).toBe(somethingElse))
+```
+
+This only takes effect within a single file though so you want to be sure you're only running the file where the test you're debugging resides. In vim's command line while in the relevant test file this would look like
+```
+:!npx jest %
+```
+
+To run it from bash you would just remove the first two characters `:!` and substitute `%` with the path to the file your relevant test is in.
+
+## Development tips
+Remember not to be afraid to add new HTML ids or classes to elements in order to make your selectors cleaner (or simply work), of course always check whether there's already a good selection available, but if not, add them wherever necessary.
+
+[This Chrome extension](https://github.com/segmentio/daydream) could also possibly be helpful to you, the selectors it generates aren't very pretty though, so it's not necessarily great (it also still missed some of the quirks like the `.mouseup` quirk mentioned below), but if you find it helpful in your process feel free to use it.
+
+And this is hopefully obvious, but if you don't already, use browser dev tools! (Chrome dev tools are great but Firefox's also got improved a lot recently I heard).
+
+## Quirks
+This section is here to just explain a few of the quirks you might see in the codebase. Especially a lot come from MaterialUI which is a fantastic package, but it also comes with some downsides since their implementation isn't very straight forward, which means you might see some weird `nightmare` code (that is hopefully commented well), and encounter some weird edge cases you'll have to handle when selecting or interacting with the website programmatically with `nightmare`. Examples include that on some buttons you need to use `.mouseup` instead of `.click` because of something related to the fact that MaterialUI uses `react-touchtap-events` (which should go away in 1.0 though which is soon to be released and we'll probably upgrade to then). Another example is that tabs don't actually get removed from the DOM tree when not visible, but instead simply get changed to `height: 0px` instead, which is the reason for the `isVisible` function (as opposed to the normal pattern of `wait(selector)`). Finally MaterialUI just has a lot of nested elements, and it can take a bit of "hacky" code to access the right elements at times.
+
+Another small thing worth mentioning is that our `npm run test:e2e` script runs with the `jest` flag `--runInBand`, this makes our tests run sequentially instead of in parallel, and the reason for this is that some (and probably the majority will end up doing this) restart the server at times, and this would of course interfere with other tests running in parallel.
+
+## Conclusion
+Remember, there are indeed a few quirks in this process, and other people have discovered good ways around most of these before. Therefore it's a great idea to read some of the tests that were already written to get a bit of inspiration from them, and if you encounter problems of course try a bit yourself first, but if you have a question that doesn't seem obvious feel free to ask in the Slack `#dev` channel, and there'll surely be someone that can help or point you to the right resource.
+
+Happy testing!


### PR DESCRIPTION
The documentation should be tightly coupled with PRs, not in a global wiki, in this PR I simply setup a folder structure and migrated the files from the wiki (minus the SWE one) into it. I will update the documentation in regards to having removed Ghost in a separate PR and documentation regarding #335 in that PR. 

We need to remember to update the links in the main README when we revert that since they currently point to the wiki.

I recommend not viewing this as the Github diff but seeing the actual file structure as that's how I imagine people interacting with it. You should be able to interact with the file structure here: https://github.com/thegazelle-ad/gazelle-server/tree/emil/migrate-wiki-to-repo/docs