### PR TITLE
Hotfix Broken Checker from Falcor 2 Update

### DIFF
--- a/src/lib/falcor/FalcorController.js
+++ b/src/lib/falcor/FalcorController.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import {
   isAppReady,
   expandCache,
-  pathSetsInCache,
   validateFalcorPathSets,
   cleanupFalcorKeys,
 } from 'lib/falcor/falcor-utilities';
@@ -303,11 +302,7 @@ export default class FalcorController extends BaseComponent {
     );
     if (!_.isEqual(oldPathSets, newPathSets)) {
       this.safeSetState({ ready: false });
-      if (pathSetsInCache(this.props.model.getCache(), newPathSets)) {
-        this.loadFalcorCache(newPathSets, falcorCallback);
-      } else {
-        this.falcorFetch(newPathSets, undefined, falcorCallback);
-      }
+      this.falcorFetch(newPathSets, undefined, falcorCallback);
     }
   }
 
@@ -322,10 +317,7 @@ export default class FalcorController extends BaseComponent {
       this.props.params,
       this.props.location.query,
     );
-    if (
-      !isAppReady() ||
-      pathSetsInCache(this.props.model.getCache(), falcorPathSets)
-    ) {
+    if (!isAppReady()) {
       this.loadFalcorCache(falcorPathSets, falcorCallback);
     } else {
       this.falcorFetch(falcorPathSets, undefined, falcorCallback);

--- a/src/lib/falcor/__tests__/expandCache.test.js
+++ b/src/lib/falcor/__tests__/expandCache.test.js
@@ -13,6 +13,11 @@ describe('expandCache', () => {
     });
   });
 
+  it('handles null values', () => {
+    const cache = { key: null };
+    expect(expandCache(cache)).toEqual(cache);
+  });
+
   it('does expand refs', () => {
     const cache = {
       a: { $type: 'ref', value: ['b'] },

--- a/src/lib/falcor/falcor-utilities.js
+++ b/src/lib/falcor/falcor-utilities.js
@@ -91,8 +91,7 @@ export function pathSetsInCache(cache, falcorPathSets) {
       return false;
     }
     const val = curObject[key];
-    // With Falcor 2 update, null values are no longer given $type
-    if (val && val.$type) {
+    if (val.$type) {
       switch (val.$type) {
         case 'error':
         case 'atom':

--- a/src/lib/falcor/falcor-utilities.js
+++ b/src/lib/falcor/falcor-utilities.js
@@ -92,7 +92,7 @@ export function pathSetsInCache(cache, falcorPathSets) {
     }
     const val = curObject[key];
     // With Falcor 2 update, null values are no longer given $type
-    if (val && val.$type) {
+    if (_.has(val, '$type')) {
       switch (val.$type) {
         case 'error':
         case 'atom':

--- a/src/lib/falcor/falcor-utilities.js
+++ b/src/lib/falcor/falcor-utilities.js
@@ -92,7 +92,7 @@ export function pathSetsInCache(cache, falcorPathSets) {
     }
     const val = curObject[key];
     // With Falcor 2 update, null values are no longer given $type
-    if (_.has(val, '$type')) {
+    if (val && val.$type) {
       switch (val.$type) {
         case 'error':
         case 'atom':

--- a/src/lib/falcor/falcor-utilities.js
+++ b/src/lib/falcor/falcor-utilities.js
@@ -91,7 +91,8 @@ export function pathSetsInCache(cache, falcorPathSets) {
       return false;
     }
     const val = curObject[key];
-    if (val.$type) {
+    // With Falcor 2 update, null values are no longer given $type
+    if (val && val.$type) {
       switch (val.$type) {
         case 'error':
         case 'atom':


### PR DESCRIPTION
Fixes a bug introduced by I believe https://github.com/thegazelle-ad/gazelle-server/pull/361

Falcor doesn't seem to give the `$type: "atom"` to null anymore which causes pathSetInCache to error out if a value has been updated to null.