### PR TITLE
Add initial db tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           key: v2-dependencies-{{ arch }}-{{ checksum "package-lock.json" }}
 
   unit_test:
-    <<: *defaults
+    <<: *defaults_with_database
     steps:
       - run:
           name: save SHA to a file
@@ -79,6 +79,10 @@ jobs:
       - restore_cache:
           keys:
             - v2-dependencies-{{ arch }}-{{ checksum "package-lock.json" }}
+
+      - run:
+          name: Wait for db
+          command: dockerize -wait tcp://localhost:3306 -timeout 1m
 
       - run: npm run test:unit
 

--- a/__tests__/helpers/db-helpers.js
+++ b/__tests__/helpers/db-helpers.js
@@ -22,7 +22,7 @@ export const getDatabaseConnection = databaseName =>
     },
   });
 
-export const createTestDatabase = databaseName =>
+const createTestDatabase = databaseName =>
   new Promise((resolve, reject) => {
     const connection = mysql.createConnection(
       _.omit(databaseConnectionConfig, 'database'),
@@ -36,6 +36,16 @@ export const createTestDatabase = databaseName =>
     });
     connection.end();
   });
+
+export const initializeTestDatabase = async (database, databaseName) => {
+  await createTestDatabase(databaseName);
+  await database.migrate.latest({
+    directory: path.join(__dirname, '../../database-management/migrations'),
+  });
+  await database.seed.run({
+    directory: path.join(__dirname, '../../database-management/seeds'),
+  });
+};
 
 export const cleanupTestDatabase = databaseName =>
   new Promise((resolve, reject) => {

--- a/__tests__/helpers/db-helpers.js
+++ b/__tests__/helpers/db-helpers.js
@@ -1,0 +1,53 @@
+// We use requireActual here in case the test calling it has mocked any
+// of these modules
+const path = require.requireActual('path');
+const fs = require.requireActual('fs');
+const JSON5 = require.requireActual('json5');
+const knex = require.requireActual('knex');
+const mysql = require.requireActual('mysql');
+const _ = require.requireActual('lodash');
+
+const databaseConnectionJSON5String = fs.readFileSync(
+  path.join(__dirname, '../../config/database.config.json5'),
+);
+
+const databaseConnectionConfig = JSON5.parse(databaseConnectionJSON5String);
+
+export const getDatabaseConnection = databaseName =>
+  knex({
+    client: 'mysql',
+    connection: {
+      ...databaseConnectionConfig,
+      database: databaseName,
+    },
+  });
+
+export const createTestDatabase = databaseName =>
+  new Promise((resolve, reject) => {
+    const connection = mysql.createConnection(
+      _.omit(databaseConnectionConfig, 'database'),
+    );
+    connection.query(`CREATE DATABASE ${databaseName};`, err => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+    connection.end();
+  });
+
+export const cleanupTestDatabase = databaseName =>
+  new Promise((resolve, reject) => {
+    const connection = mysql.createConnection(
+      _.omit(databaseConnectionConfig, 'database'),
+    );
+    connection.query(`DROP DATABASE ${databaseName};`, err => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+    connection.end();
+  });

--- a/src/lib/__mocks__/db.js
+++ b/src/lib/__mocks__/db.js
@@ -1,0 +1,3 @@
+// Just a dummy object that is needed for the mocks, all functions that use it are
+// expected to also be mocked anyway
+export const database = {};

--- a/src/lib/falcor/routes/articles/__mocks__/database-calls.js
+++ b/src/lib/falcor/routes/articles/__mocks__/database-calls.js
@@ -1,4 +1,4 @@
-export async function getPaginatedArticle(pageLength, pageIndex) {
+export async function getPaginatedArticle(database, pageLength, pageIndex) {
   const articles = [];
   for (
     let i = pageIndex * pageLength;

--- a/src/lib/falcor/routes/articles/__tests__/__snapshots__/database-calls.test.js.snap
+++ b/src/lib/falcor/routes/articles/__tests__/__snapshots__/database-calls.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getPaginatedArticle fetches expected rows from database 1`] = `
+Array [
+  Object {
+    "slug": "slug-200",
+  },
+  Object {
+    "slug": "slug-199",
+  },
+  Object {
+    "slug": "slug-198",
+  },
+  Object {
+    "slug": "slug-197",
+  },
+  Object {
+    "slug": "slug-196",
+  },
+]
+`;

--- a/src/lib/falcor/routes/articles/__tests__/by-page.test.js
+++ b/src/lib/falcor/routes/articles/__tests__/by-page.test.js
@@ -1,5 +1,6 @@
 import { routes } from '../by-page';
 
+// database-calls is automatically mocked as seen in __mocks__
 jest.enableAutomock();
 jest.unmock('../by-page');
 jest.unmock('lodash');

--- a/src/lib/falcor/routes/articles/__tests__/database-calls.test.js
+++ b/src/lib/falcor/routes/articles/__tests__/database-calls.test.js
@@ -1,0 +1,22 @@
+import { getPaginatedArticle } from '../database-calls';
+import {
+  getDatabaseConnection,
+  createTestDatabase,
+  cleanupTestDatabase,
+} from '__tests__/helpers/db-helpers';
+import path from 'path';
+
+const name = path.basename(__filename).replace(/[.-]/g, '_');
+
+const databaseName = `gazelle_test${name}${new Date().getTime()}`;
+
+const database = getDatabaseConnection(databaseName);
+
+describe('getPaginatedArticle', () => {
+  beforeEach(() => createTestDatabase(databaseName));
+  afterEach(() => cleanupTestDatabase(databaseName));
+
+  it('tests', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/lib/falcor/routes/articles/__tests__/database-calls.test.js
+++ b/src/lib/falcor/routes/articles/__tests__/database-calls.test.js
@@ -6,9 +6,9 @@ import {
 } from '__tests__/helpers/db-helpers';
 import path from 'path';
 
-const name = path.basename(__filename).replace(/[.-]/g, '_');
+const name = path.basename(__filename).replace(/[.-]/g, '_').replace(/^_+/, '');
 
-const databaseName = `gazelle_test${name}${new Date().getTime()}`;
+const databaseName = `gazelle_test_${name}_${new Date().getTime()}`;
 
 const database = getDatabaseConnection(databaseName);
 

--- a/src/lib/falcor/routes/articles/__tests__/database-calls.test.js
+++ b/src/lib/falcor/routes/articles/__tests__/database-calls.test.js
@@ -1,7 +1,7 @@
 import { getPaginatedArticle } from '../database-calls';
 import {
   getDatabaseConnection,
-  createTestDatabase,
+  initializeTestDatabase,
   cleanupTestDatabase,
 } from '__tests__/helpers/db-helpers';
 import path from 'path';
@@ -12,11 +12,43 @@ const databaseName = `gazelle_test${name}${new Date().getTime()}`;
 
 const database = getDatabaseConnection(databaseName);
 
-describe('getPaginatedArticle', () => {
-  beforeEach(() => createTestDatabase(databaseName));
-  afterEach(() => cleanupTestDatabase(databaseName));
+const maxSlugNum = 200;
 
-  it('tests', () => {
-    expect(true).toBe(true);
+// End the knex connection after all tests are done
+afterAll(() => database.destroy());
+
+describe('getPaginatedArticle', () => {
+  // We can use All instead of Each as these are only select queries
+  beforeAll(() => initializeTestDatabase(database, databaseName));
+  afterAll(() => cleanupTestDatabase(databaseName));
+
+  it('fetches expected rows from database', async () => {
+    await expect(
+      getPaginatedArticle(database, 5, 0),
+    ).resolves.toMatchSnapshot();
+  });
+
+  it('fetches the newest article for page 0', async () => {
+    await expect(getPaginatedArticle(database, 1, 0)).resolves.toEqual([
+      { slug: `slug-${maxSlugNum}` },
+    ]);
+  });
+
+  it('correctly computes offset', async () => {
+    await expect(getPaginatedArticle(database, 1, 5)).resolves.toEqual([
+      { slug: `slug-${maxSlugNum - 5}` },
+    ]);
+  });
+
+  it('throws on negative page index', async () => {
+    await expect(getPaginatedArticle(database, 1, -1)).rejects.toThrow();
+  });
+
+  it('throws on negative page length', async () => {
+    await expect(getPaginatedArticle(database, -1, 5)).rejects.toThrow();
+  });
+
+  it('returns nothing on zero page length', async () => {
+    await expect(getPaginatedArticle(database, 0, 5)).resolves.toEqual([]);
   });
 });

--- a/src/lib/falcor/routes/articles/__tests__/database-calls.test.js
+++ b/src/lib/falcor/routes/articles/__tests__/database-calls.test.js
@@ -6,7 +6,10 @@ import {
 } from '__tests__/helpers/db-helpers';
 import path from 'path';
 
-const name = path.basename(__filename).replace(/[.-]/g, '_').replace(/^_+/, '');
+const name = path
+  .basename(__filename)
+  .replace(/[.-]/g, '_')
+  .replace(/^_+/, '');
 
 const databaseName = `gazelle_test_${name}_${new Date().getTime()}`;
 

--- a/src/lib/falcor/routes/articles/by-page.js
+++ b/src/lib/falcor/routes/articles/by-page.js
@@ -2,6 +2,7 @@ import falcor from 'falcor';
 import _ from 'lodash';
 
 import { getPaginatedArticle } from './database-calls';
+import { database } from 'lib/db';
 
 const $ref = falcor.Model.ref;
 
@@ -27,7 +28,11 @@ export const routes = [
       const pageLength = pathSet.pageLengths[0];
       const pageIndex = pathSet.pageIndices[0];
 
-      const articles = await getPaginatedArticle(pageLength, pageIndex);
+      const articles = await getPaginatedArticle(
+        database,
+        pageLength,
+        pageIndex,
+      );
       const results = articles.map(({ slug }, index) => ({
         path: ['articles', 'byPage', pageLength, pageIndex, index],
         value: $ref(['articles', 'bySlug', slug]),

--- a/src/lib/falcor/routes/articles/database-calls.js
+++ b/src/lib/falcor/routes/articles/database-calls.js
@@ -1,5 +1,3 @@
-import { database } from 'lib/db';
-
 /**
  * @typedef PaginationArticle
  * @param {string} slug - The slug of the article
@@ -7,11 +5,12 @@ import { database } from 'lib/db';
 
 /**
  * Fetches a page of articles where pages are a given length
+ * @param {any} database - The knex instance to query on
  * @param {number} pageLength - Length of page to be fetched
  * @param {number} pageIndex - Which page to fetch of size pageLength
  * @returns {Promise<PaginationArticle[]>} - An array of articles on the page
  */
-export async function getPaginatedArticle(pageLength, pageIndex) {
+export async function getPaginatedArticle(database, pageLength, pageIndex) {
   const offset = pageLength * pageIndex;
   const articles = await database
     .select('slug')


### PR DESCRIPTION
Figured out a small setup to test our database queries. Using mocks for the database connection was killing me and getting super ugly, so I decided to just (do the first part of a) refactor, and make all database queries take the knex object as a parameter, as then in the tests we can just pass in a connection that points to a test database. 

This resolves #331 