### PR TITLE
Migrate to utf8mb4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ docker_no_database: &docker_no_database
 docker_with_database: &docker_with_database
   docker:
     - image: thegazelle/gazelle-main-circleci-primary:0.0.6
-    - image: circleci/mariadb:10.1
+    - image: circleci/mariadb:10.2
       environment:
         MYSQL_ROOT_PASSWORD: circleci_test_gazelle
         MYSQL_DATABASE: the_gazelle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ docker_no_database: &docker_no_database
 docker_with_database: &docker_with_database
   docker:
     - image: thegazelle/gazelle-main-circleci-primary:0.0.6
-    - image: circleci/mariadb:10.2
+    - image: circleci/mariadb:10.1
       environment:
         MYSQL_ROOT_PASSWORD: circleci_test_gazelle
         MYSQL_DATABASE: the_gazelle

--- a/.sample-env
+++ b/.sample-env
@@ -22,7 +22,7 @@
 DATABASE_HOST=127.0.0.1
 DATABASE_USER=root
 DATABASE_NAME=the_gazelle
-DATABASE_ENCODING=utf8
+DATABASE_ENCODING=utf8mb4_unicode_ci
 ## Just leave this one blank if you didn't set a password for you database.
 ## Also note that if you enabled defaults from your current file, even though
 ## the default says '[hidden]' if you just press enter your password will

--- a/__tests__/helpers/db-helpers.js
+++ b/__tests__/helpers/db-helpers.js
@@ -11,7 +11,7 @@ const databaseConnectionConfig = {
   host: envVars.DATABASE_HOST,
   database: envVars.DATABASE_NAME,
   password: envVars.DATABASE_PASSWORD,
-  encoding: envVars.DATABASE_ENCODING,
+  charset: envVars.DATABASE_ENCODING,
 };
 
 export const getDatabaseConnection = databaseName => {

--- a/database-management/migrations/20180729172934_convert-tables-to-utf8mb4.js
+++ b/database-management/migrations/20180729172934_convert-tables-to-utf8mb4.js
@@ -1,0 +1,91 @@
+/*
+ * This is just an acknowledgement that this is super hacky. But it is verified empirically
+ * that this will fix the mess our encoding has become on the production database by running
+ * it on a dump locally.
+ *
+ * It should basically not do anything when running it as an initial migration other than change
+ * the default encodings of your database which is also good anyway as then we don't have to worry
+ * about it for future migrations
+ *
+ * The fix is taken from #4 at https://coderwall.com/p/gjyuwg/mysql-convert-encoding-to-utf8-without-garbled-data
+ * And we're using utf8mb4_unicode_ci based on https://stackoverflow.com/a/766996/5711883
+ */
+
+const getConvertToUtf8mb4Query = tableName =>
+  `ALTER TABLE \`${tableName}\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`;
+const convertTableQueryToDatabaseQuery = query =>
+  query.replace('CONVERT TO ', '').replace('TABLE', 'DATABASE');
+const getConvertDatabaseToUtf8mb4Query = databaseName =>
+  convertTableQueryToDatabaseQuery(getConvertToUtf8mb4Query(databaseName));
+
+const knexfile = require('../../knexfile');
+
+const informationSchema = require('knex')({
+  client: 'mysql',
+  connection: {
+    ...knexfile.connection,
+    database: 'information_schema',
+  },
+});
+
+exports.up = async theGazelle => {
+  // When we fix the encoding this causes a slug collision as there are 2 Adam Nagys
+  // in the database (maybe with different encodings of the slug? It's a mess anyway).
+  // The one we're deleting is the one without anything associated with it. Without this
+  // the whole migration fails because of the collision
+  await theGazelle('staff')
+    .where('slug', '=', 'Ã¡dÃ¡m-nagy')
+    .del();
+
+  // Here we get the relevant columns and tables
+  let columnsToConvert;
+  let tablesToConvert;
+  try {
+    columnsToConvert = await informationSchema
+      .select('table_name', 'column_name')
+      .from('columns')
+      .where('table_schema', '=', 'the_gazelle')
+      .whereNotNull('character_set_name')
+      .where('table_name', 'not like', 'knex%');
+    tablesToConvert = (await informationSchema
+      .distinct('table_name')
+      .from('tables')
+      .where('table_schema', '=', 'the_gazelle')
+      .where('table_name', 'not like', 'knex%')).map(x => x.table_name);
+  } catch (e) {
+    // Cleaning up for good practice
+    await informationSchema.destroy();
+    throw e;
+  }
+  await informationSchema.destroy();
+
+  // We then fix our messed up encodings so that all the data is actually UTF8
+  await Promise.all(
+    columnsToConvert.map(row => {
+      const { table_name: table, column_name: col } = row;
+      return theGazelle.raw(
+        `UPDATE \`${table}\` SET \`${col}\` = @txt WHERE char_length(\`${col}\`) =  LENGTH(@txt := CONVERT(BINARY CONVERT(\`${col}\` USING latin1) USING utf8))`,
+      );
+    }),
+  );
+
+  // We then convert it to the more correct uf8mb4 as MySQL sucks and doesn't just make things work for us :(
+  await Promise.all(
+    tablesToConvert.map(tableName =>
+      theGazelle.raw(getConvertToUtf8mb4Query(tableName)),
+    ),
+  );
+
+  // We finally also change the database default to utf8mb4 so we don't have to worry about this in the future
+  await theGazelle.raw(
+    getConvertDatabaseToUtf8mb4Query(knexfile.connection.database),
+  );
+};
+
+/**
+ * We are not going to write a down migration as the data was a mess before,
+ * so it's not really recoverable and that's okay. Also we didn't change anything
+ * in the structure of the database so it wouldn't break the chain of down migrations
+ * that this one doesn't do anything.
+ */
+exports.down = async () => {};

--- a/docs/dev-environment/setting-up-dev-environment.md
+++ b/docs/dev-environment/setting-up-dev-environment.md
@@ -25,7 +25,7 @@ You should first install MariaDB, which for Linux can be done here: https://down
 After having installed MariaDB (or MySQL) we can create the database that we will use with The Gazelle:
 
 ```bash
-mysql -u root -p -e 'create database the_gazelle character set utf8'
+mysql -u root -p -e 'create database the_gazelle'
 ```
 
 When running the command it will ask you for your password for the database client which should have been set during installation of MariaDB/MySQL. It may also just be empty, in which case you can try running the first command without the `-p` flag, or just press enter without entering anything into the password prompt.

--- a/docs/dev-environment/setting-up-dev-environment.md
+++ b/docs/dev-environment/setting-up-dev-environment.md
@@ -20,7 +20,7 @@ npm install
 
 # Setup Database
 
-You should first install MariaDB, which for Linux can be done here: https://downloads.mariadb.org/mariadb/repositories, and a guide for MacOS is here: https://mariadb.com/kb/en/library/installing-mariadb-on-macos-using-homebrew/. We recommend using either a Linux distribution or MacOS as your operating system when developing for The Gazelle. We use version 10.2 of MariaDB in production / CircleCI so that's the recommended version. If you are only setting up for development and not for deployment you can also use MySQL which is 100% compatible.
+You should first install MariaDB, which for Linux can be done here: https://downloads.mariadb.org/mariadb/repositories, and a guide for MacOS is here: https://mariadb.com/kb/en/library/installing-mariadb-on-macos-using-homebrew/. We recommend using either a Linux distribution or MacOS as your operating system when developing for The Gazelle. We use version 10.1 of MariaDB in production / CircleCI so that's the recommended version. If you are only setting up for development and not for deployment you can also use MySQL which is 100% compatible.
 
 After having installed MariaDB (or MySQL) we can create the database that we will use with The Gazelle:
 

--- a/docs/dev-environment/setting-up-dev-environment.md
+++ b/docs/dev-environment/setting-up-dev-environment.md
@@ -20,7 +20,7 @@ npm install
 
 # Setup Database
 
-You should first install MariaDB, which for Linux can be done here: https://downloads.mariadb.org/mariadb/repositories, and a guide for MacOS is here: https://mariadb.com/kb/en/library/installing-mariadb-on-macos-using-homebrew/. We recommend using either a Linux distribution or MacOS as your operating system when developing for The Gazelle. We use version 10.1 of MariaDB in production / CircleCI so that's the recommended version. If you are only setting up for development and not for deployment you can also use MySQL which is 100% compatible.
+You should first install MariaDB, which for Linux can be done here: https://downloads.mariadb.org/mariadb/repositories, and a guide for MacOS is here: https://mariadb.com/kb/en/library/installing-mariadb-on-macos-using-homebrew/. We recommend using either a Linux distribution or MacOS as your operating system when developing for The Gazelle. We use version 10.2 of MariaDB in production / CircleCI so that's the recommended version. If you are only setting up for development and not for deployment you can also use MySQL which is 100% compatible.
 
 After having installed MariaDB (or MySQL) we can create the database that we will use with The Gazelle:
 

--- a/docs/dev-ops/setting-up-server.md
+++ b/docs/dev-ops/setting-up-server.md
@@ -103,7 +103,7 @@ In staging we at the time of writing just use the dummy data already set up abov
 If you are moving the production server on the other hand, you will probably have to move the database from the old server. This is done with `mysqldump` and `mysql < dumpfile.dump`. You can either do it completely manually by taking inspiration from [the backup database script](../../deployment-resources/scripts/backup-database.sh). Or you can just run that script to upload it to Google Drive where you can download the dump. To restore the database at the new server do something like
 
 ```bash
-mysql -u root -p -e 'drop database the_gazelle; create database the_gazelle character set utf8;'
+mysql -u root -p -e 'drop database the_gazelle; create database the_gazelle;'
 mysql -u root -p the_gazelle < dumpfile.dump
 ```
 

--- a/knexfile.js
+++ b/knexfile.js
@@ -9,7 +9,7 @@ const databaseConnectionConfig = {
   host: envVars.DATABASE_HOST,
   database: envVars.DATABASE_NAME,
   password: envVars.DATABASE_PASSWORD,
-  encoding: envVars.DATABASE_ENCODING,
+  charset: envVars.DATABASE_ENCODING,
 };
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2702,9 +2702,9 @@
       "dev": true
     },
     "bignumber.js": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.0.4.tgz",
-      "integrity": "sha512-LDXpJKVzEx2/OqNbG9mXBNvHuiRL4PzHCGfnANHMJ+fv68Ads3exDVJeGDJws+AoNEuca93bU3q+S0woeUaCdg=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+      "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
     },
     "bin-check": {
       "version": "2.0.0",
@@ -10857,14 +10857,48 @@
       "dev": true
     },
     "mysql": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.15.0.tgz",
-      "integrity": "sha512-C7tjzWtbN5nzkLIV+E8Crnl9bFyc7d3XJcBAvHKEVkjrYjogz3llo22q6s/hw+UcsE4/844pDob9ac+3dVjQSA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.16.0.tgz",
+      "integrity": "sha512-dPbN2LHonQp7D5ja5DJXNbCLe/HRdu+f3v61aguzNRQIrmZLOeRoymBYyeThrR6ug+FqzDL95Gc9maqZUJS+Gw==",
       "requires": {
-        "bignumber.js": "4.0.4",
-        "readable-stream": "2.3.3",
-        "safe-buffer": "5.1.1",
-        "sqlstring": "2.3.0"
+        "bignumber.js": "4.1.0",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2",
+        "sqlstring": "2.3.1"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "nan": {
@@ -16383,9 +16417,9 @@
       "dev": true
     },
     "sqlstring": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.0.tgz",
-      "integrity": "sha1-UluKT9Jtb3GqYegipsr5dtMa0qg="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
+      "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
     },
     "squeak": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9521,28 +9521,25 @@
       }
     },
     "knex": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.14.6.tgz",
-      "integrity": "sha512-A+iP8oSSmEF3JbSMfUGuJveqduDMEgyS5E/dO0ycVzAT4EE5askfunk7+37+hPqC951vnbFK/fIiNDaJIjVW0w==",
+      "version": "git+ssh://git@github.com/emilgoldsmith/knex.git#b5b984d1444fb49ab731700935abca6bbd17e676",
+      "from": "git+ssh://git@github.com/emilgoldsmith/knex.git",
       "requires": {
         "babel-runtime": "^6.26.0",
         "bluebird": "^3.5.1",
         "chalk": "2.3.2",
-        "commander": "^2.15.1",
+        "commander": "^2.16.0",
         "debug": "3.1.0",
         "inherits": "~2.0.3",
         "interpret": "^1.1.0",
         "liftoff": "2.5.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.10",
         "minimist": "1.2.0",
         "mkdirp": "^0.5.1",
         "pg-connection-string": "2.0.0",
-        "readable-stream": "2.3.6",
-        "safe-buffer": "^5.1.1",
         "tarn": "^1.1.4",
         "tildify": "1.2.0",
-        "uuid": "^3.2.1",
-        "v8flags": "^3.0.2"
+        "uuid": "^3.3.2",
+        "v8flags": "^3.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9585,33 +9582,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
         },
         "supports-color": {
           "version": "5.4.0",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "moment": "^2.14.1",
     "moment-timezone": "^0.5.14",
     "multer": "^1.3.0",
-    "mysql": "^2.11.1",
+    "mysql": "^2.16.0",
     "prismjs": "^1.14.0",
     "prop-types": "^15.6.1",
     "react": "^15.4.2",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "imagemin": "^5.3.1",
     "imagemin-jpeg-recompress": "^5.1.0",
     "immutable": "^3.8.2",
-    "knex": "^0.14.6",
+    "knex": "git+ssh://git@github.com/emilgoldsmith/knex.git",
     "lodash": "^4.17.10",
     "material-ui": "^0.17.1",
     "moment": "^2.14.1",

--- a/src/lib/falcor/routes/articles/__tests__/__snapshots__/database-calls.it.test.js.snap
+++ b/src/lib/falcor/routes/articles/__tests__/__snapshots__/database-calls.it.test.js.snap
@@ -109,19 +109,19 @@ Array [
 
 exports[`getPaginatedArticle fetches expected rows from database 1`] = `
 Array [
-  Object {
+  RowDataPacket {
     "slug": "slug-200",
   },
-  Object {
+  RowDataPacket {
     "slug": "slug-199",
   },
-  Object {
+  RowDataPacket {
     "slug": "slug-198",
   },
-  Object {
+  RowDataPacket {
     "slug": "slug-197",
   },
-  Object {
+  RowDataPacket {
     "slug": "slug-196",
   },
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please follow this template to ensure you've satisfied all the requirements for having code merged, and to make the reviewer's life a bit easier -->

## Related Issue

resolves #388 

## Description

This adds a migration that

1. Fixes all the latin1 data we had in utf8 columns, it was a real mess
2. converts to utf8mb4 as MySQL sucks and has a utf8 choice which is simply not full utf8

## How Has This Been Tested?

I have taken a dump from the production database and run all our migrations on it to check that it correctly converts the data and doesn't make our articles into garbage (which it was before if you tried putting utf8 encoding in the database config)

## Screenshots (if appropriate):

<!--- Please provide before and after screenshots for any frontend changes -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] My code follows the code style of this project. (see the [style guide](https://github.com/thegazelle-ad/gazelle-server/tree/master/docs/the-gazelle-style-guide.md))
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Coveralls reported increased code coverage, and full coverage for all the code I added / changed (or I have a good reason that I explained above for why this is not the case)
