### PR TITLE
Add OpenGraph meta tags on serverside render

### DIFF
--- a/src/components/main/ArchivesController.jsx
+++ b/src/components/main/ArchivesController.jsx
@@ -30,7 +30,7 @@ export default class ArchivesController extends FalcorController {
     return [
       { property: 'og:title', content: 'Archives | The Gazelle' },
       { property: 'og:type', content: 'website' },
-      { property: 'og:url', content: 'www.thegazelle.org/archives' },
+      { property: 'og:url', content: 'https://www.thegazelle.org/archives' },
       {
         property: 'og:image',
         content:

--- a/src/components/main/ArchivesController.jsx
+++ b/src/components/main/ArchivesController.jsx
@@ -26,6 +26,25 @@ export default class ArchivesController extends FalcorController {
     ];
   }
 
+  static getOpenGraphInformation() {
+    return [
+      { property: 'og:title', content: 'Archives | The Gazelle' },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:url', content: 'www.thegazelle.org/archives' },
+      {
+        property: 'og:image',
+        content:
+          'https://www.thegazelle.org/wp-content/themes/gazelle/images/gazelle_logo.png',
+      },
+      {
+        property: 'og:description',
+        content:
+          'The Gazelle is a weekly student publication ' +
+          'serving the NYU Abu Dhabi community.',
+      },
+    ];
+  }
+
   render() {
     if (this.state.ready) {
       if (
@@ -48,20 +67,7 @@ export default class ArchivesController extends FalcorController {
         },
 
         // Social media
-        { property: 'og:title', content: 'Archives | The Gazelle' },
-        { property: 'og:type', content: 'website' },
-        { property: 'og:url', content: 'www.thegazelle.org/archives' },
-        {
-          property: 'og:image',
-          content:
-            'https://www.thegazelle.org/wp-content/themes/gazelle/images/gazelle_logo.png',
-        },
-        {
-          property: 'og:description',
-          content:
-            'The Gazelle is a weekly student publication ' +
-            'serving the NYU Abu Dhabi community.',
-        },
+        ArchivesController.getOpenGraphInformation(),
       ];
       return (
         <div>

--- a/src/components/main/ArchivesController.jsx
+++ b/src/components/main/ArchivesController.jsx
@@ -67,7 +67,7 @@ export default class ArchivesController extends FalcorController {
         },
 
         // Social media
-        ArchivesController.getOpenGraphInformation(),
+        ...ArchivesController.getOpenGraphInformation(),
       ];
       return (
         <div>

--- a/src/components/main/ArticleController.jsx
+++ b/src/components/main/ArticleController.jsx
@@ -80,6 +80,31 @@ export default class ArticleController extends FalcorController {
     ];
   }
 
+  static getOpenGraphInformation(urlParams, falcorData) {
+    const { articleSlug } = urlParams;
+    // Access data fetched via Falcor
+    const articleData = falcorData.articles.bySlug[articleSlug];
+    // make sure article meta image has default
+    const articleMetaImage =
+      articleData.image_url ||
+      'https://thegazelle.s3.amazonaws.com/gazelle/2016/02/saadiyat-reflection.jpg';
+    return [
+      { property: 'og:title', content: `${articleData.title} | The Gazelle` },
+      { property: 'og:type', content: 'article' },
+      {
+        property: 'og:url',
+        content:
+          `https://www.thegazelle.org/issue/${articleData.issueNumber}/` +
+          `${articleData.category.slug}/${articleData.slug}`,
+      },
+      { property: 'og:image', content: articleMetaImage },
+      { property: 'og:image:width', content: '540' }, // 1.8:1 ratio
+      { property: 'og:image:height', content: '300' },
+      { property: 'og:description', content: articleData.teaser },
+      { property: 'og:site_name', content: 'The Gazelle' },
+    ];
+  }
+
   componentDidMount() {
     super.componentDidMount();
     const slug = this.props.params.articleSlug;
@@ -121,28 +146,14 @@ export default class ArticleController extends FalcorController {
       const articleData = this.state.data.articles.bySlug[articleSlug];
       const trendingData = this.state.data.trending;
       const relatedArticlesData = articleData.related;
-      // make sure article meta image has default
-      const articleMetaImage =
-        articleData.image_url ||
-        'https://thegazelle.s3.amazonaws.com/gazelle/2016/02/saadiyat-reflection.jpg';
       const meta = [
         // Search results
         { name: 'description', content: this.props.teaser },
-
         // Social media sharing
-        { property: 'og:title', content: `${articleData.title} | The Gazelle` },
-        { property: 'og:type', content: 'article' },
-        {
-          property: 'og:url',
-          content:
-            `www.thegazelle.org/issue/${articleData.issueNumber}/` +
-            `${articleData.category.slug}/${articleData.slug}`,
-        },
-        { property: 'og:image', content: articleMetaImage },
-        { property: 'og:image:width', content: '540' }, // 1.8:1 ratio
-        { property: 'og:image:height', content: '300' },
-        { property: 'og:description', content: articleData.teaser },
-        { property: 'og:site_name', content: 'The Gazelle' },
+        ...ArticleController.getOpenGraphInformation(
+          this.props.params,
+          this.state.data,
+        ),
       ];
       return (
         <div>

--- a/src/components/main/CategoryController.jsx
+++ b/src/components/main/CategoryController.jsx
@@ -5,6 +5,15 @@ import ArticleList from 'components/main/ArticleList';
 import NotFound from 'components/main/NotFound';
 import _ from 'lodash';
 
+const uppercase = str => {
+  const array = str.split(' ');
+  const newArray = [];
+
+  for (let x = 0; x < array.length; x++) {
+    newArray.push(array[x].charAt(0).toUpperCase() + array[x].slice(1));
+  }
+  return newArray.join(' ');
+};
 export default class CategoryController extends FalcorController {
   static getFalcorPathSets(params) {
     // URL Format: thegazelle.org/category/:category
@@ -43,6 +52,24 @@ export default class CategoryController extends FalcorController {
     ];
   }
 
+  static getOpenGraphInformation(urlParams, falcorData) {
+    const { category } = urlParams;
+    const categoryData = falcorData.categories.bySlug[category];
+    return [
+      { property: 'og:title', content: 'The Gazelle' },
+      { property: 'og:type', content: 'website' },
+      {
+        property: 'og:url',
+        content: `https://www.thegazelle.org/category/${categoryData.slug}`,
+      },
+      {
+        property: 'og:description',
+        content:
+          'The Gazelle is a weekly student publication serving the NYU Abu Dhabi community.',
+      },
+    ];
+  }
+
   render() {
     if (this.state.ready) {
       if (
@@ -53,15 +80,6 @@ export default class CategoryController extends FalcorController {
       }
       const { category } = this.props.params;
       const categoryData = this.state.data.categories.bySlug[category];
-      const uppercase = str => {
-        const array = str.split(' ');
-        const newArray = [];
-
-        for (let x = 0; x < array.length; x++) {
-          newArray.push(array[x].charAt(0).toUpperCase() + array[x].slice(1));
-        }
-        return newArray.join(' ');
-      };
       const meta = [
         // Search results
         {
@@ -72,17 +90,10 @@ export default class CategoryController extends FalcorController {
         },
 
         // Social media
-        { property: 'og:title', content: 'The Gazelle' },
-        { property: 'og:type', content: 'website' },
-        {
-          property: 'og:url',
-          content: `www.thegazelle.org/category/${categoryData.slug}`,
-        },
-        {
-          property: 'og:description',
-          content:
-            'The Gazelle is a weekly student publication serving the NYU Abu Dhabi community.',
-        },
+        ...CategoryController.getOpenGraphInformation(
+          this.props.params,
+          this.state.data,
+        ),
       ];
       return (
         <div className="category">

--- a/src/components/main/InteractiveArticle.jsx
+++ b/src/components/main/InteractiveArticle.jsx
@@ -34,6 +34,29 @@ export default class InteractiveArticle extends FalcorController {
     ];
   }
 
+  static getOpenGraphInformation(urlParams, falcorData) {
+    const { articleSlug } = urlParams;
+    // Access data fetched via Falcor
+    const articleData = falcorData.articles.bySlug[articleSlug];
+    // make sure article meta image has default
+    const articleMetaImage =
+      articleData.image_url ||
+      'https://thegazelle.s3.amazonaws.com/gazelle/2016/02/saadiyat-reflection.jpg';
+    return [
+      { property: 'og:title', content: `${articleData.title} | The Gazelle` },
+      { property: 'og:type', content: 'article' },
+      {
+        property: 'og:url',
+        content: `https://www.thegazelle.org/interactive/${articleData.slug}/`,
+      },
+      { property: 'og:image', content: articleMetaImage },
+      { property: 'og:image:width', content: '540' }, // 1.8:1 ratio
+      { property: 'og:image:height', content: '300' },
+      { property: 'og:description', content: articleData.teaser },
+      { property: 'og:site_name', content: 'The Gazelle' },
+    ];
+  }
+
   evaluateJavascript() {
     const articleData = this.state.data.articles.bySlug[
       this.props.params.articleSlug
@@ -80,26 +103,15 @@ export default class InteractiveArticle extends FalcorController {
       // Access data fetched via Falcor
       const articleData = this.state.data.articles.bySlug[articleSlug];
       const interactiveCode = articleData.interactiveData;
-      // make sure article meta image has default
-      const articleMetaImage =
-        articleData.image_url ||
-        'https://thegazelle.s3.amazonaws.com/gazelle/2016/02/saadiyat-reflection.jpg';
       const meta = [
         // Search results
         { name: 'description', content: articleData.teaser },
 
         // Social media sharing
-        { property: 'og:title', content: `${articleData.title} | The Gazelle` },
-        { property: 'og:type', content: 'article' },
-        {
-          property: 'og:url',
-          content: `www.thegazelle.org/interactive/${articleData.slug}/`,
-        },
-        { property: 'og:image', content: articleMetaImage },
-        { property: 'og:image:width', content: '540' }, // 1.8:1 ratio
-        { property: 'og:image:height', content: '300' },
-        { property: 'og:description', content: articleData.teaser },
-        { property: 'og:site_name', content: 'The Gazelle' },
+        InteractiveArticle.getOpenGraphInformation(
+          this.props.params,
+          this.state.data,
+        ),
       ];
       const reactHtml = {
         __html: `<div id="interactive-root">${interactiveCode.html}</div>`,

--- a/src/components/main/InteractiveArticle.jsx
+++ b/src/components/main/InteractiveArticle.jsx
@@ -108,7 +108,7 @@ export default class InteractiveArticle extends FalcorController {
         { name: 'description', content: articleData.teaser },
 
         // Social media sharing
-        InteractiveArticle.getOpenGraphInformation(
+        ...InteractiveArticle.getOpenGraphInformation(
           this.props.params,
           this.state.data,
         ),

--- a/src/components/main/InteractiveArticle.jsx
+++ b/src/components/main/InteractiveArticle.jsx
@@ -47,7 +47,7 @@ export default class InteractiveArticle extends FalcorController {
       { property: 'og:type', content: 'article' },
       {
         property: 'og:url',
-        content: `https://www.thegazelle.org/interactive/${articleData.slug}/`,
+        content: `https://www.thegazelle.org/interactive/${articleData.slug}`,
       },
       { property: 'og:image', content: articleMetaImage },
       { property: 'og:image:width', content: '540' }, // 1.8:1 ratio

--- a/src/components/main/IssueController.jsx
+++ b/src/components/main/IssueController.jsx
@@ -202,6 +202,40 @@ export default class IssueController extends FalcorController {
     ];
   }
 
+  static getOpenGraphInformation(urlParams, falcorData) {
+    let issueData;
+    let issueUrl = 'https://www.thegazelle.org';
+    if (!urlParams.issueNumber) {
+      issueData = falcorData.issues.latest;
+    } else {
+      issueData =
+        falcorData.issues.byNumber[
+          mapLegacyIssueSlugsToIssueNumber(urlParams.issueNumber)
+        ];
+      issueUrl += `/issue/${urlParams.issueNumber}`;
+    }
+    // Make sure issueImage has a default
+    const issueImage =
+      issueData.featured.image_url ||
+      'https://thegazelle.s3.amazonaws.com/gazelle/2016/02/saadiyat-reflection.jpg';
+
+    return [
+      {
+        property: 'og:title',
+        content: `Issue ${issueData.issueNumber} | The Gazelle`,
+      },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:url', content: issueUrl },
+      { property: 'og:image', content: issueImage },
+      {
+        property: 'og:description',
+        content:
+          'The Gazelle is a weekly student publication ' +
+          'serving the NYU Abu Dhabi community.',
+      },
+    ];
+  }
+
   render() {
     if (this.state.ready) {
       if (
@@ -241,11 +275,6 @@ export default class IssueController extends FalcorController {
           </div>
         ));
 
-      // Make sure issueImage has a default
-      const issueImage =
-        issueData.featured.image_url ||
-        'https://thegazelle.s3.amazonaws.com/gazelle/2016/02/saadiyat-reflection.jpg';
-
       const meta = [
         // Search results
         {
@@ -256,19 +285,10 @@ export default class IssueController extends FalcorController {
         },
 
         // Social media
-        {
-          property: 'og:title',
-          content: `Issue ${issueData.issueNumber} | The Gazelle`,
-        },
-        { property: 'og:type', content: 'website' },
-        { property: 'og:url', content: 'www.thegazelle.org' },
-        { property: 'og:image', content: issueImage },
-        {
-          property: 'og:description',
-          content:
-            'The Gazelle is a weekly student publication ' +
-            'serving the NYU Abu Dhabi community.',
-        },
+        IssueController.getOpenGraphInformation(
+          this.props.params,
+          this.state.data,
+        ),
       ];
       // Top level elements can't have classes or it will break transitions
       return (

--- a/src/components/main/IssueController.jsx
+++ b/src/components/main/IssueController.jsx
@@ -285,7 +285,7 @@ export default class IssueController extends FalcorController {
         },
 
         // Social media
-        IssueController.getOpenGraphInformation(
+        ...IssueController.getOpenGraphInformation(
           this.props.params,
           this.state.data,
         ),

--- a/src/components/main/StaffMemberController.jsx
+++ b/src/components/main/StaffMemberController.jsx
@@ -48,6 +48,25 @@ export default class StaffMemberController extends FalcorController {
     ];
   }
 
+  static getOpenGraphInformation(urlParams, falcorData) {
+    const { staffSlug } = urlParams;
+    // Access data fetched via Falcor
+    const staffData = falcorData.staff.bySlug[staffSlug];
+    return [
+      { property: 'og:title', content: `${staffData.name} | The Gazelle` },
+      { property: 'og:type', content: 'website' },
+      {
+        property: 'og:url',
+        content: `https://www.thegazelle.org/staff-member/${staffData.slug}`,
+      },
+      {
+        property: 'og:image',
+        content: staffData.image_url,
+      },
+      { property: 'og:description', content: staffData.biography },
+    ];
+  }
+
   render() {
     if (this.state.ready) {
       if (
@@ -73,13 +92,10 @@ export default class StaffMemberController extends FalcorController {
         { name: 'description', content: staffData.biography },
 
         // Social media
-        { property: 'og:title', content: `${staffData.name} | The Gazelle` },
-        { property: 'og:type', content: 'website' },
-        {
-          property: 'og:url',
-          content: `www.thegazelle.org/staff-member/${staffData.slug}`,
-        },
-        { property: 'og:description', content: staffData.biography },
+        StaffMemberController.getOpenGraphInformation(
+          this.props.params,
+          this.state.data,
+        ),
       ];
       return (
         <div>

--- a/src/components/main/StaffMemberController.jsx
+++ b/src/components/main/StaffMemberController.jsx
@@ -92,7 +92,7 @@ export default class StaffMemberController extends FalcorController {
         { name: 'description', content: staffData.biography },
 
         // Social media
-        StaffMemberController.getOpenGraphInformation(
+        ...StaffMemberController.getOpenGraphInformation(
           this.props.params,
           this.state.data,
         ),

--- a/src/components/main/TeamPageController.jsx
+++ b/src/components/main/TeamPageController.jsx
@@ -26,6 +26,18 @@ export default class TeamPageController extends FalcorController {
     ];
   }
 
+  static getOpenGraphInformation() {
+    return [
+      { property: 'og:title', content: 'Our Team | The Gazelle' },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:url', content: 'www.thegazelle.org/team' },
+      {
+        property: 'og:description',
+        content: "The Gazelle's dedicated student team.",
+      },
+    ];
+  }
+
   render() {
     if (this.state.ready) {
       if (!this.state.data || Object.keys(this.state.data).length === 0) {
@@ -43,13 +55,7 @@ export default class TeamPageController extends FalcorController {
         },
 
         // Social media
-        { property: 'og:title', content: 'Our Team | The Gazelle' },
-        { property: 'og:type', content: 'website' },
-        { property: 'og:url', content: 'www.thegazelle.org/team' },
-        {
-          property: 'og:description',
-          content: "The Gazelle's dedicated student team.",
-        },
+        ...TeamPageController.getOpenGraphInformation(),
       ];
       // Top level elements can't have classes or it will break transitions
       return (

--- a/src/components/main/TeamPageController.jsx
+++ b/src/components/main/TeamPageController.jsx
@@ -30,7 +30,7 @@ export default class TeamPageController extends FalcorController {
     return [
       { property: 'og:title', content: 'Our Team | The Gazelle' },
       { property: 'og:type', content: 'website' },
-      { property: 'og:url', content: 'www.thegazelle.org/team' },
+      { property: 'og:url', content: 'https://www.thegazelle.org/team' },
       {
         property: 'og:description',
         content: "The Gazelle's dedicated student team.",

--- a/src/components/main/TextPageController.jsx
+++ b/src/components/main/TextPageController.jsx
@@ -43,7 +43,7 @@ export default class TextPageController extends FalcorController {
       {
         property: 'og:image',
         content:
-          'https://www.thegazelle.org/wp-content/themes/gazelle/images/gazelle_logo.png',
+          'https://thegazelle.s3.amazonaws.com/gazelle/2016/02/header-logo.png',
       },
       {
         property: 'og:description',

--- a/src/components/main/TextPageController.jsx
+++ b/src/components/main/TextPageController.jsx
@@ -13,9 +13,45 @@ import TextPage from 'components/main/TextPage';
 import NotFound from 'components/main/NotFound';
 import TextPageLoad from 'transitions/TextPageLoad';
 
+const uppercase = str => {
+  const array = str.split(' ');
+  const newArray = [];
+
+  for (let x = 0; x < array.length; x++) {
+    newArray.push(array[x].charAt(0).toUpperCase() + array[x].slice(1));
+  }
+  return newArray.join(' ');
+};
+
 export default class TextPageController extends FalcorController {
   static getFalcorPathSets(params) {
     return [['infoPages', params.slug, ['title', 'html', 'slug']]];
+  }
+
+  static getOpenGraphInformation(urlParams, falcorData) {
+    const data = falcorData.infoPages[urlParams.slug];
+    return [
+      {
+        property: 'og:title',
+        content: `${uppercase(data.title)} | The Gazelle`,
+      },
+      { property: 'og:type', content: 'website' },
+      {
+        property: 'og:url',
+        content: `https://www.thegazelle.org/${data.slug}`,
+      },
+      {
+        property: 'og:image',
+        content:
+          'https://www.thegazelle.org/wp-content/themes/gazelle/images/gazelle_logo.png',
+      },
+      {
+        property: 'og:description',
+        content:
+          'The Gazelle is a weekly student publication ' +
+          'serving the NYU Abu Dhabi community.',
+      },
+    ];
   }
 
   render() {
@@ -27,15 +63,6 @@ export default class TextPageController extends FalcorController {
         return <NotFound />;
       }
       const data = this.state.data.infoPages[this.props.params.slug];
-      const uppercase = str => {
-        const array = str.split(' ');
-        const newArray = [];
-
-        for (let x = 0; x < array.length; x++) {
-          newArray.push(array[x].charAt(0).toUpperCase() + array[x].slice(1));
-        }
-        return newArray.join(' ');
-      };
       const meta = [
         // Search results
         {
@@ -46,23 +73,10 @@ export default class TextPageController extends FalcorController {
         },
 
         // Social media
-        {
-          property: 'og:title',
-          content: `${uppercase(data.title)} | The Gazelle`,
-        },
-        { property: 'og:type', content: 'website' },
-        { property: 'og:url', content: `www.thegazelle.org/${data.slug}` },
-        {
-          property: 'og:image',
-          content:
-            'https://www.thegazelle.org/wp-content/themes/gazelle/images/gazelle_logo.png',
-        },
-        {
-          property: 'og:description',
-          content:
-            'The Gazelle is a weekly student publication ' +
-            'serving the NYU Abu Dhabi community.',
-        },
+        ...TextPageController.getOpenGraphInformation(
+          this.props.params,
+          this.state.data,
+        ),
       ];
       return (
         <div>

--- a/src/server-code/main-server.js
+++ b/src/server-code/main-server.js
@@ -66,7 +66,7 @@ export default function runMainServer(serverFalcorModel) {
           (tagString, currentValue) =>
             `${tagString}<meta property="${currentValue.property}" content="${
               currentValue.content
-            }">`,
+            }" data-react-helmet="true">`, // We add this so React Helmet overwrites it
           '',
         )
       : '';

--- a/src/server-code/main-server.js
+++ b/src/server-code/main-server.js
@@ -46,7 +46,9 @@ export default function runMainServer(serverFalcorModel) {
   );
   let cssHash = md5Hash(path.join(__dirname, '../../static/build/main.css'));
 
-  const buildHtmlString = (body, cache) => {
+  // openGraphInfo is an array of objects with keys property and content such as
+  // { property: 'image', content 'https://www.images.com/some/image' }
+  const buildHtmlString = (body, cache, openGraphInfo) => {
     if (isDevelopment()) {
       // If it's development we know that the scripts may change while the server is running
       // and we can afford the computational cost of recomputing hashes. This allows us to just
@@ -58,6 +60,16 @@ export default function runMainServer(serverFalcorModel) {
       );
       cssHash = md5Hash(path.join(__dirname, '../../static/build/main.css'));
     }
+
+    const openGraphMetaTags = openGraphInfo
+      ? openGraphInfo.reduce(
+          (tagString, currentValue) =>
+            `${tagString}<meta property="og:${
+              currentValue.property
+            }" content="${currentValue.content}">`,
+          '',
+        )
+      : '';
 
     const head = Helmet.rewind();
 
@@ -75,6 +87,7 @@ export default function runMainServer(serverFalcorModel) {
             <link rel="mask-icon" href="https://s3.amazonaws.com/thegazelle/favicons/safari-pinned-tab.svg" color="#5bbad5">
             <meta name="theme-color" content="#ffffff">
             <meta name="viewport" content="width=device-width, initial-scale=1">
+            ${openGraphMetaTags}
             ${head.meta}
           </head>
           <body>

--- a/src/server-code/main-server.js
+++ b/src/server-code/main-server.js
@@ -47,7 +47,7 @@ export default function runMainServer(serverFalcorModel) {
   let cssHash = md5Hash(path.join(__dirname, '../../static/build/main.css'));
 
   // openGraphInfo is an array of objects with keys property and content such as
-  // { property: 'image', content 'https://www.images.com/some/image' }
+  // { property: 'og:image', content 'https://www.images.com/some/image' }
   const buildHtmlString = (body, cache, openGraphInfo) => {
     if (isDevelopment()) {
       // If it's development we know that the scripts may change while the server is running


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please follow this template to ensure you've satisfied all the requirements for having code merged, and to make the reviewer's life a bit easier -->

## Related Issue

Thought I would do #390, but actually that was way too hard, and a huge undertaking (big rewrites of the codebase), so I've just added the opengraph meta tags on serverside renders through a hack

## Description

When we disabled serverside rendering the javascript in our React components that was previously setting the opengraph information that let's Facebook display the images and text when you share a link was no longer running. I have therefore created a bit of a hack so we can add in this information on serverside without doing the full React render as that doesn't currently work

## How Has This Been Tested?

Manually with https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2F310780db.ngrok.io

I could probably add in some good unit tests for some of these functions, but to be honest I just don't have the time right now :(, and this is very high priority, sorry for bad practices!

## Screenshots (if appropriate):

<!--- Please provide before and after screenshots for any frontend changes -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] My code follows the code style of this project. (see the [style guide](https://github.com/thegazelle-ad/gazelle-server/tree/master/docs/the-gazelle-style-guide.md))
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Coveralls reported increased code coverage, and full coverage for all the code I added / changed (or I have a good reason that I explained above for why this is not the case)
