### PR TITLE
Allow staff slug to be changed to untaken slug

### DIFF
--- a/src/components/admin/StaffController.jsx
+++ b/src/components/admin/StaffController.jsx
@@ -236,7 +236,7 @@ class StaffController extends FalcorController {
       this.props.model
         .get(['staff', 'bySlug', this.state.slug, 'slug'])
         .then(x => {
-          if (x) {
+          if (x.json.staff.bySlug[this.state.slug].slug) {
             x = cleanupFalcorKeys(x); // eslint-disable-line no-param-reassign
             // This slug is already taken as something was returned
             this.props.displayAlert(

--- a/src/components/admin/StaffController.jsx
+++ b/src/components/admin/StaffController.jsx
@@ -238,7 +238,7 @@ class StaffController extends FalcorController {
         .then(x => {
           if (x.json.staff.bySlug[this.state.slug].slug) {
             x = cleanupFalcorKeys(x); // eslint-disable-line no-param-reassign
-            // This slug is already taken as something was returned
+            // This slug is already taken
             this.props.displayAlert(
               'The slug you chose is already taken, please change it',
             );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please follow this template to ensure you've satisfied all the requirements for having code merged, and to make the reviewer's life a bit easier -->

## Related Issue

<!--- Please link to the issue here: -->
#442 
## Description

<!--- Describe your changes in a bit more detail -->
Fix if statement that used to always evaluate to true, preventing slug from being changed
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tried to change a staff member's slug both to one that I know is taken and one that is not. Now functions as it should.
## Screenshots (if appropriate):

<!--- Please provide before and after screenshots for any frontend changes -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [ ] My code follows the code style of this project. (see the [style guide](https://github.com/thegazelle-ad/gazelle-server/tree/master/docs/the-gazelle-style-guide.md))
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Coveralls reported increased code coverage, and full coverage for all the code I added / changed (or I have a good reason that I explained above for why this is not the case)
