### PR TITLE
Add new article button on article editor page

### DIFF
--- a/src/components/admin/ArticleListController.jsx
+++ b/src/components/admin/ArticleListController.jsx
@@ -48,7 +48,7 @@ export class ArticleListController extends FalcorController {
 
   /* When we route back to ArticleListController after making changes
    * the FalcorData in ArticleListController is now out of date.
-   * This makes ArticleListController update it's state to reflect
+   * This makes ArticleListController update its state to reflect
    * the data in the DB after making edits to an Article.
    * TODO - Pub-Sub model with React-Falcor||Falcor-React
    */

--- a/src/components/admin/article/ArticleController.jsx
+++ b/src/components/admin/article/ArticleController.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { browserHistory } from 'react-router';
+import { Link, browserHistory } from 'react-router';
 import _ from 'lodash';
 import Plain from 'slate-plain-serializer';
 import moment from 'moment';
@@ -40,6 +40,8 @@ import FlatButton from 'material-ui/FlatButton';
 import ExitToApp from 'material-ui/svg-icons/action/exit-to-app';
 import Dialog from 'material-ui/Dialog';
 import RaisedButton from 'material-ui/RaisedButton';
+import FloatingActionButton from 'material-ui/FloatingActionButton';
+import ContentAdd from 'material-ui/svg-icons/content/add';
 
 // HOCs
 import { withModals } from 'components/admin/hocs/modals/withModals';
@@ -518,6 +520,20 @@ class ArticleController extends FalcorController {
               saving={this.state.saving}
               changed={this.state.changed}
             />
+          </div>
+          <div>
+            <Link to="/articles/page/0/new">
+              <FloatingActionButton
+                style={{
+                  position: 'fixed',
+                  zIndex: 50,
+                  bottom: '50px',
+                  right: '100px',
+                }}
+              >
+                <ContentAdd />
+              </FloatingActionButton>
+            </Link>
           </div>
           <Dialog
             title="Article Preview"

--- a/src/components/admin/article/ArticleController.jsx
+++ b/src/components/admin/article/ArticleController.jsx
@@ -521,8 +521,9 @@ class ArticleController extends FalcorController {
               changed={this.state.changed}
             />
           </div>
+          {this.props.children}
           <div>
-            <Link to="/articles/page/0/new">
+            <Link to={`/articles/id/${this.props.params.id}/new`}>
               <FloatingActionButton
                 style={{
                   position: 'fixed',

--- a/src/components/admin/article/CreateArticleController.jsx
+++ b/src/components/admin/article/CreateArticleController.jsx
@@ -77,7 +77,12 @@ class CreateArticleController extends React.Component {
   updateCategory = category => this.setState({ category });
 
   handleDialogClose = () => {
-    browserHistory.push(getArticleListPath(this.props.params.page));
+    if (this.props.params.page) {
+      browserHistory.push(getArticleListPath(this.props.params.page));
+    }
+    if (this.props.params.id) {
+      browserHistory.push(getArticlePath(this.props.params.id));
+    }
   };
 
   validateArticle = async () => {
@@ -138,7 +143,7 @@ class CreateArticleController extends React.Component {
       // Finally runs even if we return from the function in try and catch
       this.setState({ saving: false });
     }
-    const pathname = getArticlePath(newArticle.id, this.props.params.page);
+    const pathname = getArticlePath(newArticle.id);
     browserHistory.push({ pathname, state: { refresh: true } });
   };
 
@@ -217,9 +222,14 @@ class CreateArticleController extends React.Component {
 }
 
 CreateArticleController.propTypes = {
-  params: PropTypes.shape({
-    page: PropTypes.string.isRequired,
-  }).isRequired,
+  params: PropTypes.oneOfType([
+    PropTypes.shape({
+      page: PropTypes.string.isRequired,
+    }).isRequired,
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+    }).isRequired,
+  ]).isRequired,
   categories: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number.isRequired,
@@ -239,3 +249,4 @@ const EnhancedCreateArticleController = compose(
 )(CreateArticleController);
 
 export { EnhancedCreateArticleController as CreateArticleController };
+

--- a/src/components/admin/article/CreateArticleController.jsx
+++ b/src/components/admin/article/CreateArticleController.jsx
@@ -249,4 +249,3 @@ const EnhancedCreateArticleController = compose(
 )(CreateArticleController);
 
 export { EnhancedCreateArticleController as CreateArticleController };
-

--- a/src/routes/admin-routes.js
+++ b/src/routes/admin-routes.js
@@ -27,7 +27,9 @@ export default (
       <Route path="page/:page" component={ArticleListController}>
         <Route path="new" component={CreateArticleController} />
       </Route>
-      <Route path="id/:id" component={ArticleController} />
+      <Route path="id/:id" component={ArticleController}>
+        <Route path="new" component={CreateArticleController} />
+      </Route>
     </Route>
     <Route path="staff" component={StaffListController}>
       <Route path=":slug" component={StaffController} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please follow this template to ensure you've satisfied all the requirements for having code merged, and to make the reviewer's life a bit easier -->

## Related Issue

#440 

## Description

Added create new article button identical to the one on the article list page to the article editor page, and updated routes to keep user on the same page upon dialog close.

## How Has This Been Tested?

Created test articles from the old button and the new button, navigating both through the article list page and through creating new articles.

## Screenshots (if appropriate):

Before:
![screen shot 2019-01-23 at 5 50 15 pm](https://user-images.githubusercontent.com/24278937/51653929-70155d00-1f4a-11e9-913a-6b61b436b292.png)

After:
![screen shot 2019-01-23 at 5 49 28 pm](https://user-images.githubusercontent.com/24278937/51653936-760b3e00-1f4a-11e9-834a-23810afd918a.png)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] My code follows the code style of this project. (see the [style guide](https://github.com/thegazelle-ad/gazelle-server/tree/master/docs/the-gazelle-style-guide.md))
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Coveralls reported increased code coverage, and full coverage for all the code I added / changed (or I have a good reason that I explained above for why this is not the case)
