### PR TITLE
Move teams link from footer to navigation

### DIFF
--- a/__tests__/end-to-end/main-tests/serverside-rendering.test.js
+++ b/__tests__/end-to-end/main-tests/serverside-rendering.test.js
@@ -19,8 +19,6 @@ describe('The Gazelle server side rendering', () => {
 
   it('renders front page correctly', () =>
     testPathServersideRender(nightmare, HOST, ''));
-  it('renders team page correctly', () =>
-    testPathServersideRender(nightmare, HOST, '/team'));
   it('renders archive page correctly', () =>
     testPathServersideRender(nightmare, HOST, '/archives'));
   it('renders about page correctly', () =>
@@ -29,6 +27,8 @@ describe('The Gazelle server side rendering', () => {
     testPathServersideRender(nightmare, HOST, '/ethics'));
   it('renders category page correctly', () =>
     testPathServersideRender(nightmare, HOST, '/category/news'));
+  it('renders team page correctly', () =>
+    testPathServersideRender(nightmare, HOST, '/category/team'));
   it('renders non-default issue page correctly', () =>
     testPathServersideRender(nightmare, HOST, '/issue/100'));
   it('renders search page correctly', () =>

--- a/__tests__/end-to-end/main-tests/serverside-rendering.test.js
+++ b/__tests__/end-to-end/main-tests/serverside-rendering.test.js
@@ -19,6 +19,8 @@ describe('The Gazelle server side rendering', () => {
 
   it('renders front page correctly', () =>
     testPathServersideRender(nightmare, HOST, ''));
+  it('renders team page correctly', () =>
+    testPathServersideRender(nightmare, HOST, '/category/team'));
   it('renders archive page correctly', () =>
     testPathServersideRender(nightmare, HOST, '/archives'));
   it('renders about page correctly', () =>
@@ -27,8 +29,6 @@ describe('The Gazelle server side rendering', () => {
     testPathServersideRender(nightmare, HOST, '/ethics'));
   it('renders category page correctly', () =>
     testPathServersideRender(nightmare, HOST, '/category/news'));
-  it('renders team page correctly', () =>
-    testPathServersideRender(nightmare, HOST, '/category/team'));
   it('renders non-default issue page correctly', () =>
     testPathServersideRender(nightmare, HOST, '/issue/100'));
   it('renders search page correctly', () =>

--- a/src/components/main/Footer.jsx
+++ b/src/components/main/Footer.jsx
@@ -13,9 +13,6 @@ export default class Footer extends BaseComponent {
           <Link to="/ethics">Code of Ethics</Link>
         </li>
         <li className="footer__item">
-          <Link to="/team">Our Team</Link>
-        </li>
-        <li className="footer__item">
           <Link to="/archives">Previous Issues</Link>
         </li>
       </ul>

--- a/src/components/main/Navigation.jsx
+++ b/src/components/main/Navigation.jsx
@@ -23,6 +23,10 @@ export default class Navigation extends BaseComponent {
         name: 'multimedia',
         slug: 'media',
       },
+      {
+        name: 'team',
+        slug: 'team',
+      },
     ];
     if (this.props.navigationData != null) {
       // Wait for navigation data to come in asynchronously

--- a/src/components/main/TeamPageController.jsx
+++ b/src/components/main/TeamPageController.jsx
@@ -30,7 +30,10 @@ export default class TeamPageController extends FalcorController {
     return [
       { property: 'og:title', content: 'Our Team | The Gazelle' },
       { property: 'og:type', content: 'website' },
-      { property: 'og:url', content: 'https://www.thegazelle.org/category/team' },
+      {
+        property: 'og:url',
+        content: 'https://www.thegazelle.org/category/team',
+      },
       {
         property: 'og:description',
         content: "The Gazelle's dedicated student team.",

--- a/src/components/main/TeamPageController.jsx
+++ b/src/components/main/TeamPageController.jsx
@@ -30,7 +30,7 @@ export default class TeamPageController extends FalcorController {
     return [
       { property: 'og:title', content: 'Our Team | The Gazelle' },
       { property: 'og:type', content: 'website' },
-      { property: 'og:url', content: 'https://www.thegazelle.org/team' },
+      { property: 'og:url', content: 'https://www.thegazelle.org/category/team' },
       {
         property: 'og:description',
         content: "The Gazelle's dedicated student team.",

--- a/src/routes/main-routes.js
+++ b/src/routes/main-routes.js
@@ -26,9 +26,11 @@ export default [
     />
     <Route path="staff-member/:staffSlug" component={StaffMemberController} />
     <Route path="issue/:issueNumber" component={IssueController} />
-    <Route path="category/:category" component={CategoryController} />
+    <Route path="category">
+      <Route path="team" component={TeamPageController} />
+      <Route path=":category" component={CategoryController} />
+    </Route>
     <Route path="archives" component={ArchivesController} />
-    <Route path="team" component={TeamPageController} />
     <Route path="search" component={SearchController} />
     <Route path=":slug" component={TextPageController} />
     <Route path="*" component={NotFoundController} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please follow this template to ensure you've satisfied all the requirements for having code merged, and to make the reviewer's life a bit easier -->

## Related Issue

Editors requested moving "teams" link to nav bar rather than footer, see #504

<!--- Please link to the issue here: -->

## Description

Link to teams page is now /category/team instead of just /team, if that's a problem we can do a redirect or something
<!--- Describe your changes in a bit more detail -->

## How Has This Been Tested?

Tested locally and saw that teams was removed from footer and added to header, link works fine

Haven't tested whether teams link broke anywhere else though
<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/24278937/65421060-cdccb280-de13-11e9-8aa3-ad0be3d99320.png)

After:
![image](https://user-images.githubusercontent.com/24278937/65420879-4bdc8980-de13-11e9-9937-945c1a398287.png)

<!--- Please provide before and after screenshots for any frontend changes -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] My code follows the code style of this project. (see the [style guide](https://github.com/thegazelle-ad/gazelle-server/tree/master/docs/the-gazelle-style-guide.md))
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Coveralls reported increased code coverage, and full coverage for all the code I added / changed (or I have a good reason that I explained above for why this is not the case)
