### PR TITLE
Move team links from footer to Top Navigation

### DIFF
--- a/src/components/main/Footer.jsx
+++ b/src/components/main/Footer.jsx
@@ -13,9 +13,6 @@ export default class Footer extends BaseComponent {
           <Link to="/ethics">Code of Ethics</Link>
         </li>
         <li className="footer__item">
-          <Link to="/team">Our Team</Link>
-        </li>
-        <li className="footer__item">
           <Link to="/archives">Previous Issues</Link>
         </li>
       </ul>

--- a/src/components/main/Navigation.jsx
+++ b/src/components/main/Navigation.jsx
@@ -31,18 +31,8 @@ export default class Navigation extends BaseComponent {
     if (this.props.navigationData != null) {
       // Wait for navigation data to come in asynchronously
       const data = this.props.navigationData;
-      // const renderCategories = _.map(categories || [], category => (
-      //   <li key={category.slug} className="navigation__categories__item">
-      //     <Link
-      //       to={`/category/${category.slug}`}
-      //       activeClassName="navigation__categories__item--active"
-      //     >
-      //       {category.name}
-      //     </Link>
-      //   </li>
-      // ));
 
-      const renderCategories = _.map(categories || [], (category) => {
+      const renderCategories = _.map(categories || [], category => {
         if (category.slug === 'team') {
           return (
             <li key={category.slug} className="navigation__categories__item">
@@ -52,7 +42,8 @@ export default class Navigation extends BaseComponent {
               >
                 {category.name}
               </Link>
-            </li>)
+            </li>
+          );
         }
         return (
           <li key={category.slug} className="navigation__categories__item">
@@ -62,8 +53,9 @@ export default class Navigation extends BaseComponent {
             >
               {category.name}
             </Link>
-          </li>)
-      })
+          </li>
+        );
+      });
 
       return (
         <div>

--- a/src/components/main/Navigation.jsx
+++ b/src/components/main/Navigation.jsx
@@ -23,20 +23,47 @@ export default class Navigation extends BaseComponent {
         name: 'multimedia',
         slug: 'media',
       },
+      {
+        name: 'team',
+        slug: 'team',
+      },
     ];
     if (this.props.navigationData != null) {
       // Wait for navigation data to come in asynchronously
       const data = this.props.navigationData;
-      const renderCategories = _.map(categories || [], category => (
-        <li key={category.slug} className="navigation__categories__item">
-          <Link
-            to={`/category/${category.slug}`}
-            activeClassName="navigation__categories__item--active"
-          >
-            {category.name}
-          </Link>
-        </li>
-      ));
+      // const renderCategories = _.map(categories || [], category => (
+      //   <li key={category.slug} className="navigation__categories__item">
+      //     <Link
+      //       to={`/category/${category.slug}`}
+      //       activeClassName="navigation__categories__item--active"
+      //     >
+      //       {category.name}
+      //     </Link>
+      //   </li>
+      // ));
+
+      const renderCategories = _.map(categories || [], (category)=>{
+        if (category.slug==='team'){
+          return (
+          <li>
+            <Link
+              to="/team"
+              activeClassName="navigation__categories__item--active"
+            >
+              {category.name}
+            </Link>
+          </li>)
+        }
+          return (
+            <li>
+              <Link
+                to={`/category/${category.slug}`}
+                activeClassName="navigation__categories__item--active"
+              >
+                {category.name}
+              </Link>
+            </li>)
+      })
 
       return (
         <div>

--- a/src/components/main/Navigation.jsx
+++ b/src/components/main/Navigation.jsx
@@ -42,27 +42,27 @@ export default class Navigation extends BaseComponent {
       //   </li>
       // ));
 
-      const renderCategories = _.map(categories || [], (category)=>{
-        if (category.slug==='team'){
+      const renderCategories = _.map(categories || [], (category) => {
+        if (category.slug === 'team') {
           return (
-          <li>
-            <Link
-              to="/team"
-              activeClassName="navigation__categories__item--active"
-            >
-              {category.name}
-            </Link>
-          </li>)
-        }
-          return (
-            <li>
+            <li key={category.slug} className="navigation__categories__item">
               <Link
-                to={`/category/${category.slug}`}
+                to="/team"
                 activeClassName="navigation__categories__item--active"
               >
                 {category.name}
               </Link>
             </li>)
+        }
+        return (
+          <li key={category.slug} className="navigation__categories__item">
+            <Link
+              to={`/category/${category.slug}`}
+              activeClassName="navigation__categories__item--active"
+            >
+              {category.name}
+            </Link>
+          </li>)
       })
 
       return (


### PR DESCRIPTION
## Related Issue

#505 - Editors requested Teams to be moved up to top

## Description

Changed the Navigation List on top to include team now

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

After Change: 
![image](https://user-images.githubusercontent.com/27405695/65482118-f4b3d480-de65-11e9-9aeb-0637a82f4e5c.png)


## Checklist:

- [x] My code follows the code style of this project. (see the [style guide](https://github.com/thegazelle-ad/gazelle-server/tree/master/docs/the-gazelle-style-guide.md))
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Coveralls reported increased code coverage, and full coverage for all the code I added / changed (or I have a good reason that I explained above for why this is not the case)
