### PR TITLE
Make articles without issue numbers not render

### DIFF
--- a/src/components/main/ArticlePreview.jsx
+++ b/src/components/main/ArticlePreview.jsx
@@ -12,8 +12,9 @@ export default class ArticlePreview extends BaseComponent {
     const { article } = this.props;
     let url;
     if (article.issueNumber) {
-      url = `/issue/${article.issueNumber.toString()}/${article.category.slug
-        }/${article.slug}`;
+      url = `/issue/${article.issueNumber.toString()}/${
+        article.category.slug
+      }/${article.slug}`;
     } else {
       return null;
     }

--- a/src/components/main/ArticlePreview.jsx
+++ b/src/components/main/ArticlePreview.jsx
@@ -10,9 +10,13 @@ import AuthorList from 'components/main/AuthorList';
 export default class ArticlePreview extends BaseComponent {
   render() {
     const { article } = this.props;
-    let url = `/issue/${article.issueNumber.toString()}/${
-      article.category.slug
-    }/${article.slug}`;
+    let url;
+    if (article.issueNumber) {
+      url = `/issue/${article.issueNumber.toString()}/${article.category.slug
+        }/${article.slug}`;
+    } else {
+      return null;
+    }
     if (article.is_interactive) {
       // We don't use standard url for interactive articles
       url = `/interactive/${article.slug}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please follow this template to ensure you've satisfied all the requirements for having code merged, and to make the reviewer's life a bit easier -->

## Related Issue

<!--- Please link to the issue here: -->
#525 
## Description

<!--- Describe your changes in a bit more detail -->
Prevented rendering when article does not have an `issueNumber`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested locally with the broken staff pages

## Screenshots (if appropriate):

<!--- Please provide before and after screenshots for any frontend changes -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] My code follows the code style of this project. (see the [style guide](https://github.com/thegazelle-ad/gazelle-server/tree/master/docs/the-gazelle-style-guide.md))
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Coveralls reported increased code coverage, and full coverage for all the code I added / changed (or I have a good reason that I explained above for why this is not the case)
